### PR TITLE
Fix NullPointerException when executing commands on offline players

### DIFF
--- a/src/main/java/com/bitaspire/cyberlevels/UserManagerImpl.java
+++ b/src/main/java/com/bitaspire/cyberlevels/UserManagerImpl.java
@@ -113,7 +113,19 @@ final class UserManagerImpl<N extends Number> implements UserManager<N> {
         for (LevelUser<N> user : users.values())
             try {
                 String n = Objects.requireNonNull(user.getName());
-                if (n.equalsIgnoreCase(name)) return user;
+                if (n.equalsIgnoreCase(name)) {
+                    // Check if user is stored as OfflineUser but is actually online
+                    if (!user.isOnline()) {
+                        Player online = Bukkit.getPlayer(user.getUuid());
+                        if (online != null && online.isOnline()) {
+                            // Player is online but we have OfflineUser in cache - reload as OnlineUser
+                            main.logger("&eDetected online player " + name + " cached as OfflineUser. Reloading...");
+                            loadPlayer(online);
+                            return users.get(user.getUuid());
+                        }
+                    }
+                    return user;
+                }
             } catch (Exception ignored) {}
 
         return null;


### PR DESCRIPTION
Problem:
- Commands like `/clv addExp 100 PlayerName` threw NPE when player was cached as OfflineUser
- System tried to access Player object for permission/multiplier checks on offline users
- OfflineUser.getPlayer() used Objects.requireNonNull which threw NPE when player was null

Changes:
1. BaseSystem.java - OfflineUser.getPlayer():
   - Replaced Objects.requireNonNull with explicit null check
   - Added descriptive IllegalStateException with player name and UUID

2. UserManagerImpl.java - getUser(String):
   - Added automatic conversion from OfflineUser to OnlineUser when player is online
   - Checks if cached OfflineUser is actually online and reloads if needed

3. BaseSystem.java - changeExp():
   - Added isOnline() check before accessing player permissions
   - Wrapped permission checks in try-catch for safety
   - Skip multiplier calculation for offline players

4. BaseSystem.java - message sending:
   - Only send level-up/exp messages when player is online
   - Wrapped all message sending in isOnline() checks

5. BaseSystem.java - sendLevelReward():
   - Only give rewards when player is online
   - Still tracks highest rewarded level for offline players

6. BaseSystem.java - updateLevel():
   - Level updates work offline, but messages only sent when online

Result:
- Commands now work correctly for both online and offline players
- No more NullPointerException crashes
- Better error messages when operations require online player
- Automatic cache synchronization when player status changes

Fixes: #7 NPE when using admin commands on players