### PR TITLE
Fix: Implement a fix for displaying non-freezed placeholders internally or with PAPI

### DIFF
--- a/src/main/java/com/bitaspire/cyberlevels/CyberLevels.java
+++ b/src/main/java/com/bitaspire/cyberlevels/CyberLevels.java
@@ -11,9 +11,9 @@ import com.bitaspire.cyberlevels.level.LevelSystem;
 import com.bitaspire.cyberlevels.listener.Listeners;
 import com.bitaspire.cyberlevels.user.Database;
 import com.bitaspire.cyberlevels.user.UserManager;
+import com.bitaspire.scheduler.GlobalScheduler;
 import com.bitaspire.takion.TakionLib;
 import com.bitaspire.takion.message.MessageSender;
-import com.bitaspire.scheduler.GlobalScheduler;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.experimental.Accessors;
@@ -41,6 +41,7 @@ public final class CyberLevels extends JavaPlugin {
     LevelSystem<?> levelSystem;
 
     UserManager<?> userManager;
+
     @Getter(AccessLevel.NONE)
     Database<?> database;
 
@@ -67,14 +68,14 @@ public final class CyberLevels extends JavaPlugin {
         CoreSettings settings = core.getSettings();
         settings.setBootColor('d');
         settings.setBootLogo(
-                "&d╭━━━╮&7╱╱╱&d╭╮&7╱╱╱╱╱╱&d╭╮&7╱╱╱╱╱╱╱╱╱╱╱&d╭╮",
-                "&d┃╭━╮┃&7╱╱╱&d┃┃&7╱╱╱╱╱╱&d┃┃&7╱╱╱╱╱╱╱╱╱╱╱&d┃┃",
-                "&d┃┃&7╱&d╰╋╮&7╱&d╭┫╰━┳━━┳━┫┃&7╱╱&d╭━━┳╮╭┳━━┫┃╭━━╮",
-                "&d┃┃&7╱&d╭┫┃&7╱&d┃┃╭╮┃┃━┫╭┫┃&7╱&d╭┫┃━┫╰╯┃┃━┫┃┃━━┫",
-                "&d┃╰━╯┃╰━╯┃╰╯┃┃━┫┃┃╰━╯┃┃━╋╮╭┫┃━┫╰╋━━┃",
-                "&d╰━━━┻━╮╭┻━━┻━━┻╯╰━━━┻━━╯╰╯╰━━┻━┻━━╯",
-                "&7╱╱╱╱&d╭━╯┃  &7Authors: &f" + getAuthors(),
-                "&7╱╱╱╱&d╰━━╯  &7Version: &f" + this.getDescription().getVersion()
+            "&d╭━━━╮&7╱╱╱&d╭╮&7╱╱╱╱╱╱&d╭╮&7╱╱╱╱╱╱╱╱╱╱╱&d╭╮",
+            "&d┃╭━╮┃&7╱╱╱&d┃┃&7╱╱╱╱╱╱&d┃┃&7╱╱╱╱╱╱╱╱╱╱╱&d┃┃",
+            "&d┃┃&7╱&d╰╋╮&7╱&d╭┫╰━┳━━┳━┫┃&7╱╱&d╭━━┳╮╭┳━━┫┃╭━━╮",
+            "&d┃┃&7╱&d╭┫┃&7╱&d┃┃╭╮┃┃━┫╭┫┃&7╱&d╭┫┃━┫╰╯┃┃━┫┃┃━━┫",
+            "&d┃╰━╯┃╰━╯┃╰╯┃┃━┫┃┃╰━╯┃┃━╋╮╭┫┃━┫╰╋━━┃",
+            "&d╰━━━┻━╮╭┻━━┻━━┻╯╰━━━┻━━╯╰╯╰━━┻━┻━━╯",
+            "&7╱╱╱╱&d╭━╯┃  &7Authors: &f" + getAuthors(),
+            "&7╱╱╱╱&d╰━━╯  &7Version: &f" + this.getDescription().getVersion()
         );
 
         core.loadStart(false);
@@ -101,18 +102,20 @@ public final class CyberLevels extends JavaPlugin {
         cache = new Cache(this);
 
         long start = System.currentTimeMillis();
-        BaseSystem<?> system = !cache.config().useBigDecimalSystem() ?
-                new DoubleSystem(this) :
-                new BigDecimalSystem(this);
+        BaseSystem<?> system = !cache.config().useBigDecimalSystem()
+            ? new DoubleSystem(this)
+            : new BigDecimalSystem(this);
 
         logger("&dChecking level system type...");
         levelSystem = system;
 
         logger(
-                "&7Loaded &e" + system.getClass().getSimpleName() +
-                        "&7 in &a" +
-                        (System.currentTimeMillis() - start) +
-                        "ms&7.", ""
+            "&7Loaded &e" +
+                system.getClass().getSimpleName() +
+                "&7 in &a" +
+                (System.currentTimeMillis() - start) +
+                "ms&7.",
+            ""
         );
 
         UserManagerImpl<?> manager = new UserManagerImpl<>(this, system);
@@ -142,18 +145,28 @@ public final class CyberLevels extends JavaPlugin {
 
         hookManager.unregister();
 
-        userManager.saveOnlinePlayers(true);
+        if (userManager instanceof UserManagerImpl<?>) (
+            (UserManagerImpl<?>) userManager
+        ).saveOnlinePlayersSync(true);
+        else userManager.saveOnlinePlayers(true);
+
         userManager.cancelAutoSave();
 
         if (database != null) {
-            database.disconnect();
+            if (database instanceof DatabaseFactory.DatabaseImpl<?>) (
+                (DatabaseFactory.DatabaseImpl<?>) database
+            ).disconnectSync();
+            else database.disconnect();
             if (isEnabled()) logger("");
         }
         listeners.unregister();
     }
 
     public String getAuthors() {
-        return this.getDescription().getAuthors().toString().replaceAll("[\\[\\]]", "");
+        return this.getDescription()
+            .getAuthors()
+            .toString()
+            .replaceAll("[\\[\\]]", "");
     }
 
     public double serverVersion() {

--- a/src/main/java/com/bitaspire/cyberlevels/DatabaseFactory.java
+++ b/src/main/java/com/bitaspire/cyberlevels/DatabaseFactory.java
@@ -5,18 +5,19 @@ import com.bitaspire.cyberlevels.user.Database;
 import com.bitaspire.cyberlevels.user.LevelUser;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import java.sql.*;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
 import lombok.experimental.UtilityClass;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
-import java.sql.*;
-import java.util.*;
-import java.util.concurrent.CompletableFuture;
-
 @UtilityClass
 class DatabaseFactory {
 
-    abstract static class DatabaseImpl<N extends Number> implements Database<N> {
+    abstract static class DatabaseImpl<
+        N extends Number
+    > implements Database<N> {
 
         final CyberLevels main;
         final BaseSystem<N> system;
@@ -31,6 +32,7 @@ class DatabaseFactory {
         }
 
         abstract String getTable();
+
         abstract HikariConfig createConfig();
 
         String qCol(String name) {
@@ -41,16 +43,37 @@ class DatabaseFactory {
             return name;
         }
 
-        abstract PreparedStatement prepareUpsert(Connection c, UUID uuid, long level, String exp, long updatedAt) throws SQLException;
-        abstract PreparedStatement prepareUpsertMeta(Connection c, UUID uuid, long highestRewarded, long updatedAt) throws SQLException;
+        abstract PreparedStatement prepareUpsert(
+            Connection c,
+            UUID uuid,
+            long level,
+            String exp,
+            long updatedAt
+        ) throws SQLException;
 
-        abstract Set<String> getExistingColumns(Connection conn) throws SQLException;
-        abstract boolean isExpColumnTextual(Connection conn) throws SQLException;
-        abstract boolean hasPrimaryKeyOnUuid(Connection conn) throws SQLException;
+        abstract PreparedStatement prepareUpsertMeta(
+            Connection c,
+            UUID uuid,
+            long highestRewarded,
+            long updatedAt
+        ) throws SQLException;
+
+        abstract Set<String> getExistingColumns(Connection conn)
+            throws SQLException;
+
+        abstract boolean isExpColumnTextual(Connection conn)
+            throws SQLException;
+
+        abstract boolean hasPrimaryKeyOnUuid(Connection conn)
+            throws SQLException;
 
         abstract void createTargetTable(Connection conn) throws SQLException;
-        abstract void dropTableIfExists(Connection conn, String table) throws SQLException;
-        abstract void renameTable(Connection conn, String from, String to) throws SQLException;
+
+        abstract void dropTableIfExists(Connection conn, String table)
+            throws SQLException;
+
+        abstract void renameTable(Connection conn, String from, String to)
+            throws SQLException;
 
         String metaTable() {
             return getTable() + "_meta";
@@ -61,19 +84,37 @@ class DatabaseFactory {
             String idType = sqlite ? "TEXT" : "VARCHAR(36)";
             String longType = sqlite ? "INTEGER" : "BIGINT";
 
-            String sql = "CREATE TABLE IF NOT EXISTS " + qTab(metaTable()) + " (" +
-                    qCol("UUID") + " " + idType + " PRIMARY KEY," +
-                    qCol("HIGHEST_REWARDED") + " " + longType + "," +
-                    qCol("UPDATED_AT") + " " + longType + " NOT NULL DEFAULT 0" +
-                    ")";
+            String sql =
+                "CREATE TABLE IF NOT EXISTS " +
+                qTab(metaTable()) +
+                " (" +
+                qCol("UUID") +
+                " " +
+                idType +
+                " PRIMARY KEY," +
+                qCol("HIGHEST_REWARDED") +
+                " " +
+                longType +
+                "," +
+                qCol("UPDATED_AT") +
+                " " +
+                longType +
+                " NOT NULL DEFAULT 0" +
+                ")";
             try (Statement st = conn.createStatement()) {
                 st.executeUpdate(sql);
             }
         }
 
         long readHighestRewarded(Connection conn, UUID uuid) {
-            String sql = "SELECT " + qCol("HIGHEST_REWARDED") + " FROM " + qTab(metaTable()) +
-                    " WHERE " + qCol("UUID") + "=?";
+            String sql =
+                "SELECT " +
+                qCol("HIGHEST_REWARDED") +
+                " FROM " +
+                qTab(metaTable()) +
+                " WHERE " +
+                qCol("UUID") +
+                "=?";
             try (PreparedStatement ps = conn.prepareStatement(sql)) {
                 ps.setString(1, uuid.toString());
                 try (ResultSet rs = ps.executeQuery()) {
@@ -95,21 +136,31 @@ class DatabaseFactory {
             main.logger("&dAttempting to connect to " + type + "...");
             long l = System.currentTimeMillis();
 
-            main.scheduler().runTaskAsynchronously(() -> {
-                try {
-                    dataSource = new HikariDataSource(createConfig());
+            try {
+                dataSource = new HikariDataSource(createConfig());
 
-                    try (Connection conn = dataSource.getConnection()) {
-                        ensureTargetSchema(conn);
-                        ensureMetaSchema(conn);
-                    }
-
-                    main.logger("&7Connected to &e" + type + "&7 successfully in &a" + (System.currentTimeMillis() - l) + "ms&7.");
-                } catch (Exception e) {
-                    main.logger("&cThere was an issue connecting to " + type + " Database.");
-                    e.printStackTrace();
+                try (Connection conn = dataSource.getConnection()) {
+                    ensureTargetSchema(conn);
+                    ensureMetaSchema(conn);
                 }
-            });
+
+                main.logger(
+                    "&7Connected to &e" +
+                        type +
+                        "&7 successfully in &a" +
+                        (System.currentTimeMillis() - l) +
+                        "ms&7."
+                );
+            } catch (Exception e) {
+                main.logger(
+                    "&cThere was an issue connecting to " + type + " Database."
+                );
+                try {
+                    if (dataSource != null) dataSource.close();
+                } catch (Exception ignored) {}
+                dataSource = null;
+                e.printStackTrace();
+            }
         }
 
         @Override
@@ -122,9 +173,19 @@ class DatabaseFactory {
             Runnable close = () -> {
                 try {
                     dataSource.close();
-                    main.logger("&7Disconnected from &e" + type + "&7 successfully in &a" + (System.currentTimeMillis() - l) + "ms&7.");
+                    main.logger(
+                        "&7Disconnected from &e" +
+                            type +
+                            "&7 successfully in &a" +
+                            (System.currentTimeMillis() - l) +
+                            "ms&7."
+                    );
                 } catch (Exception e) {
-                    main.logger("&cThere was an issue disconnecting from " + type + " Database.");
+                    main.logger(
+                        "&cThere was an issue disconnecting from " +
+                            type +
+                            " Database."
+                    );
                     e.printStackTrace();
                 } finally {
                     dataSource = null;
@@ -138,6 +199,33 @@ class DatabaseFactory {
             }
         }
 
+        void disconnectSync() {
+            if (!isConnected()) return;
+
+            main.logger("&dAttempting to disconnect from " + type + "...");
+            long l = System.currentTimeMillis();
+
+            try {
+                dataSource.close();
+                main.logger(
+                    "&7Disconnected from &e" +
+                        type +
+                        "&7 successfully in &a" +
+                        (System.currentTimeMillis() - l) +
+                        "ms&7."
+                );
+            } catch (Exception e) {
+                main.logger(
+                    "&cThere was an issue disconnecting from " +
+                        type +
+                        " Database."
+                );
+                e.printStackTrace();
+            } finally {
+                dataSource = null;
+            }
+        }
+
         void ensureTargetSchema(Connection conn) throws SQLException {
             if (!tableExists(conn, getTable())) {
                 createTargetTable(conn);
@@ -145,19 +233,27 @@ class DatabaseFactory {
             }
 
             Set<String> cols = getExistingColumns(conn);
-            boolean needMigration = !cols.contains("UUID") || !cols.contains("LEVEL") || !cols.contains("EXP");
+            boolean needMigration =
+                !cols.contains("UUID") ||
+                !cols.contains("LEVEL") ||
+                !cols.contains("EXP");
 
-            if (cols.contains("MAX_LEVEL") ||
-                    !cols.contains("UPDATED_AT") ||
-                    !isExpColumnTextual(conn) ||
-                    !hasPrimaryKeyOnUuid(conn))
-                needMigration = true;
+            if (
+                cols.contains("MAX_LEVEL") ||
+                !cols.contains("UPDATED_AT") ||
+                !isExpColumnTextual(conn) ||
+                !hasPrimaryKeyOnUuid(conn)
+            ) needMigration = true;
 
             if (needMigration) migrateTableToCanonical(conn);
         }
 
         boolean tableExists(Connection conn, String table) throws SQLException {
-            try (ResultSet rs = conn.getMetaData().getTables(null, null, table, null)) {
+            try (
+                ResultSet rs = conn
+                    .getMetaData()
+                    .getTables(null, null, table, null)
+            ) {
                 return rs.next();
             }
         }
@@ -166,7 +262,15 @@ class DatabaseFactory {
             String table = getTable();
             String backup = table + "_backup_" + System.currentTimeMillis();
 
-            main.logger("&e" + type + ": migrating table '" + table + "' to canonical schema (backup: " + backup + ")...");
+            main.logger(
+                "&e" +
+                    type +
+                    ": migrating table '" +
+                    table +
+                    "' to canonical schema (backup: " +
+                    backup +
+                    ")..."
+            );
 
             conn.setAutoCommit(false);
             try (Statement ignored = conn.createStatement()) {
@@ -177,9 +281,10 @@ class DatabaseFactory {
                 Map<UUID, Row> bestByUuid = new LinkedHashMap<>();
 
                 String selectSQL = "SELECT * FROM " + qTab(backup);
-                try (PreparedStatement ps = conn.prepareStatement(selectSQL);
-                     ResultSet rs = ps.executeQuery()) {
-
+                try (
+                    PreparedStatement ps = conn.prepareStatement(selectSQL);
+                    ResultSet rs = ps.executeQuery()
+                ) {
                     while (rs.next()) {
                         String uuidStr = safeGet(rs, "UUID");
                         if (uuidStr == null || uuidStr.isEmpty()) continue;
@@ -204,23 +309,46 @@ class DatabaseFactory {
                         long updated = safeGetLong(rs, "UPDATED_AT", 0L);
                         long maxLevel = safeGetLong(rs, "MAX_LEVEL", -1L);
 
-                        Row row = new Row(uuid, level, expStr, updated, maxLevel);
+                        Row row = new Row(
+                            uuid,
+                            level,
+                            expStr,
+                            updated,
+                            maxLevel
+                        );
                         Row prev = bestByUuid.get(uuid);
-                        if (prev == null ||
-                                row.updatedAt > prev.updatedAt ||
-                                (row.updatedAt == prev.updatedAt && row.level > prev.level)) {
-                            if (prev != null)
-                                row.maxLevel = Math.max(row.maxLevel, prev.maxLevel);
+                        if (
+                            prev == null ||
+                            row.updatedAt > prev.updatedAt ||
+                            (row.updatedAt == prev.updatedAt &&
+                                row.level > prev.level)
+                        ) {
+                            if (prev != null) row.maxLevel = Math.max(
+                                row.maxLevel,
+                                prev.maxLevel
+                            );
                             bestByUuid.put(uuid, row);
                         } else {
-                            prev.maxLevel = Math.max(prev.maxLevel, row.maxLevel);
+                            prev.maxLevel = Math.max(
+                                prev.maxLevel,
+                                row.maxLevel
+                            );
                         }
                     }
                 }
 
-                String insertSQL = "INSERT INTO " + qTab(table) + " (" +
-                        qCol("UUID") + "," + qCol("LEVEL") + "," + qCol("EXP") + "," + qCol("UPDATED_AT") +
-                        ") VALUES (?,?,?,?)";
+                String insertSQL =
+                    "INSERT INTO " +
+                    qTab(table) +
+                    " (" +
+                    qCol("UUID") +
+                    "," +
+                    qCol("LEVEL") +
+                    "," +
+                    qCol("EXP") +
+                    "," +
+                    qCol("UPDATED_AT") +
+                    ") VALUES (?,?,?,?)";
 
                 try (PreparedStatement ins = conn.prepareStatement(insertSQL)) {
                     for (Row r : bestByUuid.values()) {
@@ -235,7 +363,14 @@ class DatabaseFactory {
 
                 for (Row r : bestByUuid.values()) {
                     long highest = (r.maxLevel >= 0 ? r.maxLevel : r.level);
-                    try (PreparedStatement up = prepareUpsertMeta(conn, r.uuid, highest, r.updatedAt)) {
+                    try (
+                        PreparedStatement up = prepareUpsertMeta(
+                            conn,
+                            r.uuid,
+                            highest,
+                            r.updatedAt
+                        )
+                    ) {
                         up.executeUpdate();
                     }
                 }
@@ -243,15 +378,32 @@ class DatabaseFactory {
                 dropTableIfExists(conn, backup);
 
                 conn.commit();
-                main.logger("&a" + type + ": migration for '" + table + "' completed (" + bestByUuid.size() + " rows).");
+                main.logger(
+                    "&a" +
+                        type +
+                        ": migration for '" +
+                        table +
+                        "' completed (" +
+                        bestByUuid.size() +
+                        " rows)."
+                );
             } catch (SQLException ex) {
                 conn.rollback();
-                main.logger("&c" + type + ": migration failed, attempting rollback restore...");
+                main.logger(
+                    "&c" +
+                        type +
+                        ": migration failed, attempting rollback restore..."
+                );
                 try {
                     dropTableIfExists(conn, getTable());
                     renameTable(conn, backup, getTable());
                 } catch (SQLException restoreEx) {
-                    main.logger("&c" + type + ": failed to restore backup: " + restoreEx.getMessage());
+                    main.logger(
+                        "&c" +
+                            type +
+                            ": failed to restore backup: " +
+                            restoreEx.getMessage()
+                    );
                 }
                 throw ex;
             } finally {
@@ -260,13 +412,20 @@ class DatabaseFactory {
         }
 
         static class Row {
+
             final UUID uuid;
             final long level;
             final String exp;
             final long updatedAt;
             long maxLevel;
 
-            Row(UUID uuid, long level, String exp, long updatedAt, long maxLevel) {
+            Row(
+                UUID uuid,
+                long level,
+                String exp,
+                long updatedAt,
+                long maxLevel
+            ) {
                 this.uuid = uuid;
                 this.level = level;
                 this.exp = exp;
@@ -324,20 +483,32 @@ class DatabaseFactory {
             if (!isConnected()) return false;
             CompletableFuture<Boolean> future = new CompletableFuture<>();
 
-            main.scheduler().runTaskAsynchronously(() -> {
-                try (Connection connection = dataSource.getConnection();
-                     PreparedStatement statement = connection.prepareStatement(
-                             "SELECT 1 FROM " + qTab(getTable()) + " WHERE " + qCol("UUID") + "=?")) {
-                    statement.setString(1, user.getUuid().toString());
-                    try (ResultSet rs = statement.executeQuery()) {
-                        future.complete(rs.next());
+            main
+                .scheduler()
+                .runTaskAsynchronously(() -> {
+                    try (
+                        Connection connection = dataSource.getConnection();
+                        PreparedStatement statement =
+                            connection.prepareStatement(
+                                "SELECT 1 FROM " +
+                                    qTab(getTable()) +
+                                    " WHERE " +
+                                    qCol("UUID") +
+                                    "=?"
+                            )
+                    ) {
+                        statement.setString(1, user.getUuid().toString());
+                        try (ResultSet rs = statement.executeQuery()) {
+                            future.complete(rs.next());
+                        }
+                    } catch (Exception e) {
+                        main.logger(
+                            "&cFailed to check if user exists in table."
+                        );
+                        e.printStackTrace();
+                        future.complete(false);
                     }
-                } catch (Exception e) {
-                    main.logger("&cFailed to check if user exists in table.");
-                    e.printStackTrace();
-                    future.complete(false);
-                }
-            });
+                });
 
             try {
                 return future.get();
@@ -348,13 +519,19 @@ class DatabaseFactory {
 
         void setRewardLevel(LevelUser<N> user, long level) {
             try {
-                user.getClass().getMethod("setHighestRewardedLevel", long.class).invoke(user, level);
+                user
+                    .getClass()
+                    .getMethod("setHighestRewardedLevel", long.class)
+                    .invoke(user, level);
             } catch (Exception ignored) {}
         }
 
         long getRewardLevel(LevelUser<N> user) {
             try {
-                return (long) user.getClass().getMethod("getHighestRewardedLevel").invoke(user);
+                return (long) user
+                    .getClass()
+                    .getMethod("getHighestRewardedLevel")
+                    .invoke(user);
             } catch (Exception ignored) {
                 return user.getLevel();
             }
@@ -365,7 +542,9 @@ class DatabaseFactory {
             if (!isConnected()) return;
             if (isUserLoaded(user)) return;
 
-            String levelStr = String.valueOf(main.levelSystem().getStartLevel());
+            String levelStr = String.valueOf(
+                main.levelSystem().getStartLevel()
+            );
             String expStr = String.valueOf(main.levelSystem().getStartExp());
 
             if (!defValues) {
@@ -376,14 +555,26 @@ class DatabaseFactory {
             final String finalLevelStr = levelStr;
             final String finalExpStr = expStr;
 
-            main.scheduler().runTaskAsynchronously(() -> {
-                String sql = "INSERT INTO " + qTab(getTable()) + " (" +
-                        qCol("UUID") + "," + qCol("LEVEL") + "," + qCol("EXP") + "," + qCol("UPDATED_AT") +
+            main
+                .scheduler()
+                .runTaskAsynchronously(() -> {
+                    String sql =
+                        "INSERT INTO " +
+                        qTab(getTable()) +
+                        " (" +
+                        qCol("UUID") +
+                        "," +
+                        qCol("LEVEL") +
+                        "," +
+                        qCol("EXP") +
+                        "," +
+                        qCol("UPDATED_AT") +
                         ") VALUES (?,?,?,?)";
 
-                    try (Connection connection = dataSource.getConnection();
-                         PreparedStatement st = connection.prepareStatement(sql))
-                    {
+                    try (
+                        Connection connection = dataSource.getConnection();
+                        PreparedStatement st = connection.prepareStatement(sql)
+                    ) {
                         st.setString(1, user.getUuid().toString());
                         st.setLong(2, Long.parseLong(finalLevelStr));
                         st.setString(3, finalExpStr);
@@ -392,19 +583,34 @@ class DatabaseFactory {
 
                         long now = System.currentTimeMillis();
                         long highest = getRewardLevel(user);
-                        try (PreparedStatement pm = prepareUpsertMeta(connection, user.getUuid(), highest, now)) {
+                        try (
+                            PreparedStatement pm = prepareUpsertMeta(
+                                connection,
+                                user.getUuid(),
+                                highest,
+                                now
+                            )
+                        ) {
                             pm.executeUpdate();
                         }
                     } catch (Exception e) {
-                        main.logger("&cFailed to add user " + user.getName() + ".");
+                        main.logger(
+                            "&cFailed to add user " + user.getName() + "."
+                        );
                         e.printStackTrace();
                     }
-            });
+                });
         }
 
         @Override
         public void updateUser(LevelUser<N> user) {
             if (!isConnected()) return;
+            main.scheduler().runTaskAsynchronously(() -> updateUserSync(user));
+        }
+
+        void updateUserSync(LevelUser<N> user) {
+            if (!isConnected()) return;
+
             final UUID uuid = user.getUuid();
             final long now = System.currentTimeMillis();
             final String expStr = String.valueOf(user.getExp());
@@ -412,47 +618,84 @@ class DatabaseFactory {
             final String name = user.getName();
             final long highest = getRewardLevel(user);
 
-            main.scheduler().runTaskAsynchronously(() -> {
-                try (Connection connection = dataSource.getConnection()) {
-                    try (PreparedStatement st = prepareUpsert(connection, uuid, level, expStr, now)) {
-                        st.executeUpdate();
-                    }
-
-                    try (PreparedStatement stm = prepareUpsertMeta(connection, uuid, highest, now)) {
-                        stm.executeUpdate();
-                    }
-                } catch (Exception e) {
-                    main.logger("&cFailed to update user " + name + ".");
-                    e.printStackTrace();
+            try (Connection connection = dataSource.getConnection()) {
+                try (
+                    PreparedStatement st = prepareUpsert(
+                        connection,
+                        uuid,
+                        level,
+                        expStr,
+                        now
+                    )
+                ) {
+                    st.executeUpdate();
                 }
-            });
+
+                try (
+                    PreparedStatement stm = prepareUpsertMeta(
+                        connection,
+                        uuid,
+                        highest,
+                        now
+                    )
+                ) {
+                    stm.executeUpdate();
+                }
+            } catch (Exception e) {
+                main.logger("&cFailed to update user " + name + ".");
+                e.printStackTrace();
+            }
         }
 
         @Override
         public void removeUser(UUID uuid) {
             if (!isConnected()) return;
 
-            main.scheduler().runTaskAsynchronously(() -> {
-                String sql = "DELETE FROM " + qTab(getTable()) + " WHERE " + qCol("UUID") + "=?";
-                String metaSql = "DELETE FROM " + qTab(metaTable()) + " WHERE " + qCol("UUID") + "=?";
-                try (Connection connection = dataSource.getConnection();
-                     PreparedStatement st = connection.prepareStatement(sql);
-                     PreparedStatement sm = connection.prepareStatement(metaSql)) {
-                    st.setString(1, uuid.toString());
-                    st.executeUpdate();
+            main
+                .scheduler()
+                .runTaskAsynchronously(() -> {
+                    String sql =
+                        "DELETE FROM " +
+                        qTab(getTable()) +
+                        " WHERE " +
+                        qCol("UUID") +
+                        "=?";
+                    String metaSql =
+                        "DELETE FROM " +
+                        qTab(metaTable()) +
+                        " WHERE " +
+                        qCol("UUID") +
+                        "=?";
+                    try (
+                        Connection connection = dataSource.getConnection();
+                        PreparedStatement st = connection.prepareStatement(sql);
+                        PreparedStatement sm = connection.prepareStatement(
+                            metaSql
+                        )
+                    ) {
+                        st.setString(1, uuid.toString());
+                        st.executeUpdate();
 
-                    sm.setString(1, uuid.toString());
-                    sm.executeUpdate();
-                } catch (Exception e) {
-                    main.logger("&cFailed to remove user " + uuid + " from " + type + " database.");
-                    e.printStackTrace();
-                }
-            });
+                        sm.setString(1, uuid.toString());
+                        sm.executeUpdate();
+                    } catch (Exception e) {
+                        main.logger(
+                            "&cFailed to remove user " +
+                                uuid +
+                                " from " +
+                                type +
+                                " database."
+                        );
+                        e.printStackTrace();
+                    }
+                });
         }
 
         @Override
         public LevelUser<N> getUser(Player player) {
-            return !isConnected() || player == null ? null : getUser(player.getUniqueId());
+            return !isConnected() || player == null
+                ? null
+                : getUser(player.getUniqueId());
         }
 
         @Override
@@ -461,38 +704,57 @@ class DatabaseFactory {
 
             CompletableFuture<LevelUser<N>> future = new CompletableFuture<>();
 
-            main.scheduler().runTaskAsynchronously(() -> {
-                String sql = "SELECT " + qCol("LEVEL") + "," + qCol("EXP") + " FROM " + qTab(getTable()) + " WHERE " + qCol("UUID") + "=?";
+            main
+                .scheduler()
+                .runTaskAsynchronously(() -> {
+                    String sql =
+                        "SELECT " +
+                        qCol("LEVEL") +
+                        "," +
+                        qCol("EXP") +
+                        " FROM " +
+                        qTab(getTable()) +
+                        " WHERE " +
+                        qCol("UUID") +
+                        "=?";
 
-                try (Connection connection = dataSource.getConnection();
-                     PreparedStatement st = connection.prepareStatement(sql)) {
-                    st.setString(1, uuid.toString());
+                    try (
+                        Connection connection = dataSource.getConnection();
+                        PreparedStatement st = connection.prepareStatement(sql)
+                    ) {
+                        st.setString(1, uuid.toString());
 
-                    try (ResultSet rs = st.executeQuery()) {
-                        if (!rs.next()) {
-                            future.complete(null);
-                            return;
+                        try (ResultSet rs = st.executeQuery()) {
+                            if (!rs.next()) {
+                                future.complete(null);
+                                return;
+                            }
+
+                            LevelUser<N> user = system.createUser(uuid);
+                            long level = rs.getLong("LEVEL");
+                            user.setLevel(level, false);
+
+                            String expStr = rs.getString("EXP");
+                            if (expStr == null) expStr = "0";
+                            user.setExp(expStr, false, false, false);
+
+                            long hr = readHighestRewarded(connection, uuid);
+                            setRewardLevel(
+                                user,
+                                hr >= 0 ? hr : user.getLevel()
+                            );
+
+                            future.complete(user);
                         }
-
-                        LevelUser<N> user = system.createUser(uuid);
-                        long level = rs.getLong("LEVEL");
-                        user.setLevel(level, false);
-
-                        String expStr = rs.getString("EXP");
-                        if (expStr == null) expStr = "0";
-                        user.setExp(expStr, false, false, false);
-
-                        long hr = readHighestRewarded(connection, uuid);
-                        setRewardLevel(user, hr >= 0 ? hr : user.getLevel());
-
-                        future.complete(user);
+                    } catch (Exception e) {
+                        main.logger(
+                            "&cFailed to get player data for " + uuid + ".",
+                            ""
+                        );
+                        e.printStackTrace();
+                        future.complete(null);
                     }
-                } catch (Exception e) {
-                    main.logger("&cFailed to get player data for " + uuid + ".", "");
-                    e.printStackTrace();
-                    future.complete(null);
-                }
-            });
+                });
 
             try {
                 return future.get();
@@ -508,26 +770,35 @@ class DatabaseFactory {
 
             CompletableFuture<Set<UUID>> future = new CompletableFuture<>();
 
-            main.scheduler().runTaskAsynchronously(() -> {
-                String sql = "SELECT " + qCol("UUID") + " FROM " + qTab(getTable());
+            main
+                .scheduler()
+                .runTaskAsynchronously(() -> {
+                    String sql =
+                        "SELECT " + qCol("UUID") + " FROM " + qTab(getTable());
 
-                try (Connection connection = dataSource.getConnection();
-                     PreparedStatement statement = connection.prepareStatement(sql);
-                     ResultSet rs = statement.executeQuery())
-                {
-                    Set<UUID> result = new LinkedHashSet<>();
-                    while (rs.next()) {
-                        try {
-                            result.add(UUID.fromString(rs.getString("UUID")));
-                        } catch (Exception ignored) {}
+                    try (
+                        Connection connection = dataSource.getConnection();
+                        PreparedStatement statement =
+                            connection.prepareStatement(sql);
+                        ResultSet rs = statement.executeQuery()
+                    ) {
+                        Set<UUID> result = new LinkedHashSet<>();
+                        while (rs.next()) {
+                            try {
+                                result.add(
+                                    UUID.fromString(rs.getString("UUID"))
+                                );
+                            } catch (Exception ignored) {}
+                        }
+                        future.complete(result);
+                    } catch (SQLException e) {
+                        main.logger(
+                            "&cFailed to fetch UUIDs from " + type + "."
+                        );
+                        e.printStackTrace();
+                        future.complete(new LinkedHashSet<>());
                     }
-                    future.complete(result);
-                } catch (SQLException e) {
-                    main.logger("&cFailed to fetch UUIDs from " + type + ".");
-                    e.printStackTrace();
-                    future.complete(new LinkedHashSet<>());
-                }
-            });
+                });
 
             try {
                 return future.get();
@@ -563,7 +834,17 @@ class DatabaseFactory {
         @Override
         HikariConfig createConfig() {
             HikariConfig config = new HikariConfig();
-            config.setJdbcUrl("jdbc:mysql://" + ip + ":" + port + "/" + database + "?useSSL=" + ssl + "&autoReconnect=true&useUnicode=true&characterEncoding=utf8");
+            config.setJdbcUrl(
+                "jdbc:mysql://" +
+                    ip +
+                    ":" +
+                    port +
+                    "/" +
+                    database +
+                    "?useSSL=" +
+                    ssl +
+                    "&autoReconnect=true&useUnicode=true&characterEncoding=utf8"
+            );
             config.setUsername(username);
             config.setPassword(password);
             config.setConnectionTimeout(10000);
@@ -594,15 +875,53 @@ class DatabaseFactory {
         }
 
         @Override
-        PreparedStatement prepareUpsert(Connection c, UUID uuid, long level, String exp, long updatedAt) throws SQLException {
+        PreparedStatement prepareUpsert(
+            Connection c,
+            UUID uuid,
+            long level,
+            String exp,
+            long updatedAt
+        ) throws SQLException {
             String sql =
-                    "INSERT INTO " + qTab(getTable()) + " (" +
-                            qCol("UUID") + "," + qCol("LEVEL") + "," + qCol("EXP") + "," + qCol("UPDATED_AT") + ") " +
-                            "VALUES (?,?,?,?) " +
-                            "ON DUPLICATE KEY UPDATE " +
-                            qCol("LEVEL") + " = IF(VALUES(" + qCol("UPDATED_AT") + ") >= " + qCol("UPDATED_AT") + ", VALUES(" + qCol("LEVEL") + ")," + qCol("LEVEL") + ")," +
-                            qCol("EXP") + " = IF(VALUES(" + qCol("UPDATED_AT") + ") >= " + qCol("UPDATED_AT") + ", VALUES(" + qCol("EXP") + ")," + qCol("EXP") + ")," +
-                            qCol("UPDATED_AT") + " = GREATEST(" + qCol("UPDATED_AT") + ", VALUES(" + qCol("UPDATED_AT") + "))";
+                "INSERT INTO " +
+                qTab(getTable()) +
+                " (" +
+                qCol("UUID") +
+                "," +
+                qCol("LEVEL") +
+                "," +
+                qCol("EXP") +
+                "," +
+                qCol("UPDATED_AT") +
+                ") " +
+                "VALUES (?,?,?,?) " +
+                "ON DUPLICATE KEY UPDATE " +
+                qCol("LEVEL") +
+                " = IF(VALUES(" +
+                qCol("UPDATED_AT") +
+                ") >= " +
+                qCol("UPDATED_AT") +
+                ", VALUES(" +
+                qCol("LEVEL") +
+                ")," +
+                qCol("LEVEL") +
+                ")," +
+                qCol("EXP") +
+                " = IF(VALUES(" +
+                qCol("UPDATED_AT") +
+                ") >= " +
+                qCol("UPDATED_AT") +
+                ", VALUES(" +
+                qCol("EXP") +
+                ")," +
+                qCol("EXP") +
+                ")," +
+                qCol("UPDATED_AT") +
+                " = GREATEST(" +
+                qCol("UPDATED_AT") +
+                ", VALUES(" +
+                qCol("UPDATED_AT") +
+                "))";
             PreparedStatement ps = c.prepareStatement(sql);
             ps.setString(1, uuid.toString());
             ps.setLong(2, level);
@@ -612,13 +931,35 @@ class DatabaseFactory {
         }
 
         @Override
-        PreparedStatement prepareUpsertMeta(Connection c, UUID uuid, long highest, long updatedAt) throws SQLException {
-            String sql = "INSERT INTO " + qTab(metaTable()) + " (" +
-                    qCol("UUID") + "," + qCol("HIGHEST_REWARDED") + "," + qCol("UPDATED_AT") +
-                    ") VALUES (?,?,?) " +
-                    "ON DUPLICATE KEY UPDATE " +
-                    qCol("HIGHEST_REWARDED") + " = GREATEST(" + qCol("HIGHEST_REWARDED") + ", VALUES(" + qCol("HIGHEST_REWARDED") + "))," +
-                    qCol("UPDATED_AT") + " = GREATEST(" + qCol("UPDATED_AT") + ", VALUES(" + qCol("UPDATED_AT") + "))";
+        PreparedStatement prepareUpsertMeta(
+            Connection c,
+            UUID uuid,
+            long highest,
+            long updatedAt
+        ) throws SQLException {
+            String sql =
+                "INSERT INTO " +
+                qTab(metaTable()) +
+                " (" +
+                qCol("UUID") +
+                "," +
+                qCol("HIGHEST_REWARDED") +
+                "," +
+                qCol("UPDATED_AT") +
+                ") VALUES (?,?,?) " +
+                "ON DUPLICATE KEY UPDATE " +
+                qCol("HIGHEST_REWARDED") +
+                " = GREATEST(" +
+                qCol("HIGHEST_REWARDED") +
+                ", VALUES(" +
+                qCol("HIGHEST_REWARDED") +
+                "))," +
+                qCol("UPDATED_AT") +
+                " = GREATEST(" +
+                qCol("UPDATED_AT") +
+                ", VALUES(" +
+                qCol("UPDATED_AT") +
+                "))";
             PreparedStatement ps = c.prepareStatement(sql);
             ps.setString(1, uuid.toString());
             ps.setLong(2, highest);
@@ -629,11 +970,14 @@ class DatabaseFactory {
         @Override
         Set<String> getExistingColumns(Connection conn) throws SQLException {
             Set<String> cols = new HashSet<>();
-            String sql = "SELECT COLUMN_NAME FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = ?";
+            String sql =
+                "SELECT COLUMN_NAME FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = ?";
             try (PreparedStatement ps = conn.prepareStatement(sql)) {
                 ps.setString(1, getTable());
                 try (ResultSet rs = ps.executeQuery()) {
-                    while (rs.next()) cols.add(rs.getString(1).toUpperCase(Locale.ENGLISH));
+                    while (rs.next()) cols.add(
+                        rs.getString(1).toUpperCase(Locale.ENGLISH)
+                    );
                 }
             }
             return cols;
@@ -641,7 +985,8 @@ class DatabaseFactory {
 
         @Override
         boolean isExpColumnTextual(Connection conn) throws SQLException {
-            String sql = "SELECT DATA_TYPE FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = ? AND column_name = 'EXP'";
+            String sql =
+                "SELECT DATA_TYPE FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = ? AND column_name = 'EXP'";
             try (PreparedStatement ps = conn.prepareStatement(sql)) {
                 ps.setString(1, getTable());
                 try (ResultSet rs = ps.executeQuery()) {
@@ -658,11 +1003,12 @@ class DatabaseFactory {
 
         @Override
         boolean hasPrimaryKeyOnUuid(Connection conn) throws SQLException {
-            String sql = "SELECT k.COLUMN_NAME " +
-                    "FROM information_schema.table_constraints t " +
-                    "JOIN information_schema.key_column_usage k " +
-                    "ON t.constraint_name = k.constraint_name AND t.table_schema = k.table_schema AND t.table_name = k.table_name " +
-                    "WHERE t.constraint_type = 'PRIMARY KEY' AND t.table_schema = DATABASE() AND t.table_name = ?";
+            String sql =
+                "SELECT k.COLUMN_NAME " +
+                "FROM information_schema.table_constraints t " +
+                "JOIN information_schema.key_column_usage k " +
+                "ON t.constraint_name = k.constraint_name AND t.table_schema = k.table_schema AND t.table_name = k.table_name " +
+                "WHERE t.constraint_type = 'PRIMARY KEY' AND t.table_schema = DATABASE() AND t.table_name = ?";
             try (PreparedStatement ps = conn.prepareStatement(sql)) {
                 ps.setString(1, getTable());
                 try (ResultSet rs = ps.executeQuery()) {
@@ -677,29 +1023,42 @@ class DatabaseFactory {
 
         @Override
         void createTargetTable(Connection conn) throws SQLException {
-            String sql = "CREATE TABLE IF NOT EXISTS " + qTab(getTable()) + " (" +
-                    qCol("UUID") + " VARCHAR(36) NOT NULL," +
-                    qCol("LEVEL") + " BIGINT," +
-                    qCol("EXP") + " TEXT," +
-                    qCol("UPDATED_AT") + " BIGINT NOT NULL DEFAULT 0," +
-                    "PRIMARY KEY (" + qCol("UUID") + ")) " +
-                    "CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
+            String sql =
+                "CREATE TABLE IF NOT EXISTS " +
+                qTab(getTable()) +
+                " (" +
+                qCol("UUID") +
+                " VARCHAR(36) NOT NULL," +
+                qCol("LEVEL") +
+                " BIGINT," +
+                qCol("EXP") +
+                " TEXT," +
+                qCol("UPDATED_AT") +
+                " BIGINT NOT NULL DEFAULT 0," +
+                "PRIMARY KEY (" +
+                qCol("UUID") +
+                ")) " +
+                "CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
             try (Statement st = conn.createStatement()) {
                 st.executeUpdate(sql);
             }
         }
 
         @Override
-        void dropTableIfExists(Connection conn, String table) throws SQLException {
+        void dropTableIfExists(Connection conn, String table)
+            throws SQLException {
             try (Statement st = conn.createStatement()) {
                 st.executeUpdate("DROP TABLE IF EXISTS " + qTab(table));
             }
         }
 
         @Override
-        void renameTable(Connection conn, String from, String to) throws SQLException {
+        void renameTable(Connection conn, String from, String to)
+            throws SQLException {
             try (Statement st = conn.createStatement()) {
-                st.executeUpdate("RENAME TABLE " + qTab(from) + " TO " + qTab(to));
+                st.executeUpdate(
+                    "RENAME TABLE " + qTab(from) + " TO " + qTab(to)
+                );
             }
         }
     }
@@ -715,12 +1074,19 @@ class DatabaseFactory {
             this.table = db.getTable();
         }
 
-        @Override String getTable() { return table; }
+        @Override
+        String getTable() {
+            return table;
+        }
 
         @Override
         HikariConfig createConfig() {
             HikariConfig config = new HikariConfig();
-            config.setJdbcUrl("jdbc:sqlite:" + filePath + "?busy_timeout=5000&journal_mode=WAL&synchronous=NORMAL");
+            config.setJdbcUrl(
+                "jdbc:sqlite:" +
+                    filePath +
+                    "?busy_timeout=5000&journal_mode=WAL&synchronous=NORMAL"
+            );
             config.setMaximumPoolSize(2);
             config.setMinimumIdle(1);
             config.setConnectionTimeout(10000);
@@ -743,15 +1109,65 @@ class DatabaseFactory {
         }
 
         @Override
-        PreparedStatement prepareUpsert(Connection c, UUID uuid, long level, String exp, long updatedAt) throws SQLException {
+        PreparedStatement prepareUpsert(
+            Connection c,
+            UUID uuid,
+            long level,
+            String exp,
+            long updatedAt
+        ) throws SQLException {
             String sql =
-                    "INSERT INTO " + qTab(getTable()) + " (" +
-                            qCol("UUID") + "," + qCol("LEVEL") + "," + qCol("EXP") + "," + qCol("UPDATED_AT") + ") " +
-                            "VALUES (?,?,?,?) " +
-                            "ON CONFLICT(" + qCol("UUID") + ") DO UPDATE SET " +
-                            qCol("LEVEL") + " = CASE WHEN excluded." + qCol("UPDATED_AT") + " >= " + qTab(getTable()) + "." + qCol("UPDATED_AT") + " THEN excluded." + qCol("LEVEL") + " ELSE " + qTab(getTable()) + "." + qCol("LEVEL") + " END," +
-                            qCol("EXP") + " = CASE WHEN excluded." + qCol("UPDATED_AT") + " >= " + qTab(getTable()) + "." + qCol("UPDATED_AT") + " THEN excluded." + qCol("EXP") + " ELSE " + qTab(getTable()) + "." + qCol("EXP") + " END," +
-                            qCol("UPDATED_AT") + " = MAX(" + qTab(getTable()) + "." + qCol("UPDATED_AT") + ", excluded." + qCol("UPDATED_AT") + ")";
+                "INSERT INTO " +
+                qTab(getTable()) +
+                " (" +
+                qCol("UUID") +
+                "," +
+                qCol("LEVEL") +
+                "," +
+                qCol("EXP") +
+                "," +
+                qCol("UPDATED_AT") +
+                ") " +
+                "VALUES (?,?,?,?) " +
+                "ON CONFLICT(" +
+                qCol("UUID") +
+                ") DO UPDATE SET " +
+                qCol("LEVEL") +
+                " = CASE WHEN excluded." +
+                qCol("UPDATED_AT") +
+                " >= " +
+                qTab(getTable()) +
+                "." +
+                qCol("UPDATED_AT") +
+                " THEN excluded." +
+                qCol("LEVEL") +
+                " ELSE " +
+                qTab(getTable()) +
+                "." +
+                qCol("LEVEL") +
+                " END," +
+                qCol("EXP") +
+                " = CASE WHEN excluded." +
+                qCol("UPDATED_AT") +
+                " >= " +
+                qTab(getTable()) +
+                "." +
+                qCol("UPDATED_AT") +
+                " THEN excluded." +
+                qCol("EXP") +
+                " ELSE " +
+                qTab(getTable()) +
+                "." +
+                qCol("EXP") +
+                " END," +
+                qCol("UPDATED_AT") +
+                " = MAX(" +
+                qTab(getTable()) +
+                "." +
+                qCol("UPDATED_AT") +
+                ", excluded." +
+                qCol("UPDATED_AT") +
+                ")";
             PreparedStatement ps = c.prepareStatement(sql);
             ps.setString(1, uuid.toString());
             ps.setLong(2, level);
@@ -761,13 +1177,41 @@ class DatabaseFactory {
         }
 
         @Override
-        PreparedStatement prepareUpsertMeta(Connection c, UUID uuid, long highest, long updatedAt) throws SQLException {
-            String sql = "INSERT INTO " + qTab(metaTable()) + " (" +
-                    qCol("UUID") + "," + qCol("HIGHEST_REWARDED") + "," + qCol("UPDATED_AT") +
-                    ") VALUES (?,?,?) " +
-                    "ON CONFLICT(" + qCol("UUID") + ") DO UPDATE SET " +
-                    qCol("HIGHEST_REWARDED") + " = MAX(" + qTab(metaTable()) + "." + qCol("HIGHEST_REWARDED") + ", excluded." + qCol("HIGHEST_REWARDED") + ")," +
-                    qCol("UPDATED_AT") + " = MAX(" + qTab(metaTable()) + "." + qCol("UPDATED_AT") + ", excluded." + qCol("UPDATED_AT") + ")";
+        PreparedStatement prepareUpsertMeta(
+            Connection c,
+            UUID uuid,
+            long highest,
+            long updatedAt
+        ) throws SQLException {
+            String sql =
+                "INSERT INTO " +
+                qTab(metaTable()) +
+                " (" +
+                qCol("UUID") +
+                "," +
+                qCol("HIGHEST_REWARDED") +
+                "," +
+                qCol("UPDATED_AT") +
+                ") VALUES (?,?,?) " +
+                "ON CONFLICT(" +
+                qCol("UUID") +
+                ") DO UPDATE SET " +
+                qCol("HIGHEST_REWARDED") +
+                " = MAX(" +
+                qTab(metaTable()) +
+                "." +
+                qCol("HIGHEST_REWARDED") +
+                ", excluded." +
+                qCol("HIGHEST_REWARDED") +
+                ")," +
+                qCol("UPDATED_AT") +
+                " = MAX(" +
+                qTab(metaTable()) +
+                "." +
+                qCol("UPDATED_AT") +
+                ", excluded." +
+                qCol("UPDATED_AT") +
+                ")";
             PreparedStatement ps = c.prepareStatement(sql);
             ps.setString(1, uuid.toString());
             ps.setLong(2, highest);
@@ -778,8 +1222,12 @@ class DatabaseFactory {
         @Override
         Set<String> getExistingColumns(Connection conn) throws SQLException {
             Set<String> cols = new HashSet<>();
-            try (PreparedStatement ps = conn.prepareStatement("PRAGMA table_info(" + getTable() + ")");
-                 ResultSet rs = ps.executeQuery()) {
+            try (
+                PreparedStatement ps = conn.prepareStatement(
+                    "PRAGMA table_info(" + getTable() + ")"
+                );
+                ResultSet rs = ps.executeQuery()
+            ) {
                 while (rs.next()) {
                     cols.add(rs.getString("name").toUpperCase(Locale.ENGLISH));
                 }
@@ -789,8 +1237,12 @@ class DatabaseFactory {
 
         @Override
         boolean isExpColumnTextual(Connection conn) throws SQLException {
-            try (PreparedStatement ps = conn.prepareStatement("PRAGMA table_info(" + getTable() + ")");
-                 ResultSet rs = ps.executeQuery()) {
+            try (
+                PreparedStatement ps = conn.prepareStatement(
+                    "PRAGMA table_info(" + getTable() + ")"
+                );
+                ResultSet rs = ps.executeQuery()
+            ) {
                 while (rs.next()) {
                     String name = rs.getString("name");
                     if (!"EXP".equalsIgnoreCase(name)) continue;
@@ -805,8 +1257,12 @@ class DatabaseFactory {
 
         @Override
         boolean hasPrimaryKeyOnUuid(Connection conn) throws SQLException {
-            try (PreparedStatement ps = conn.prepareStatement("PRAGMA table_info(" + getTable() + ")");
-                 ResultSet rs = ps.executeQuery()) {
+            try (
+                PreparedStatement ps = conn.prepareStatement(
+                    "PRAGMA table_info(" + getTable() + ")"
+                );
+                ResultSet rs = ps.executeQuery()
+            ) {
                 while (rs.next()) {
                     String name = rs.getString("name");
                     int pk = rs.getInt("pk");
@@ -818,28 +1274,39 @@ class DatabaseFactory {
 
         @Override
         void createTargetTable(Connection conn) throws SQLException {
-            String sql = "CREATE TABLE IF NOT EXISTS " + qTab(getTable()) + " (" +
-                    qCol("UUID") + " TEXT PRIMARY KEY," +
-                    qCol("LEVEL") + " INTEGER," +
-                    qCol("EXP") + " TEXT," +
-                    qCol("UPDATED_AT") + " INTEGER NOT NULL DEFAULT 0" +
-                    ")";
+            String sql =
+                "CREATE TABLE IF NOT EXISTS " +
+                qTab(getTable()) +
+                " (" +
+                qCol("UUID") +
+                " TEXT PRIMARY KEY," +
+                qCol("LEVEL") +
+                " INTEGER," +
+                qCol("EXP") +
+                " TEXT," +
+                qCol("UPDATED_AT") +
+                " INTEGER NOT NULL DEFAULT 0" +
+                ")";
             try (Statement st = conn.createStatement()) {
                 st.executeUpdate(sql);
             }
         }
 
         @Override
-        void dropTableIfExists(Connection conn, String table) throws SQLException {
+        void dropTableIfExists(Connection conn, String table)
+            throws SQLException {
             try (Statement st = conn.createStatement()) {
                 st.executeUpdate("DROP TABLE IF EXISTS " + qTab(table));
             }
         }
 
         @Override
-        void renameTable(Connection conn, String from, String to) throws SQLException {
+        void renameTable(Connection conn, String from, String to)
+            throws SQLException {
             try (Statement st = conn.createStatement()) {
-                st.executeUpdate("ALTER TABLE " + qTab(from) + " RENAME TO " + qTab(to));
+                st.executeUpdate(
+                    "ALTER TABLE " + qTab(from) + " RENAME TO " + qTab(to)
+                );
             }
         }
     }
@@ -860,14 +1327,17 @@ class DatabaseFactory {
             this.table = db.getTable();
         }
 
-        @Override String getTable() {
+        @Override
+        String getTable() {
             return table;
         }
 
         @Override
         HikariConfig createConfig() {
             HikariConfig config = new HikariConfig();
-            config.setJdbcUrl("jdbc:postgresql://" + ip + ":" + port + "/" + database);
+            config.setJdbcUrl(
+                "jdbc:postgresql://" + ip + ":" + port + "/" + database
+            );
             config.setUsername(username);
             config.setPassword(password);
             config.setConnectionTimeout(10000);
@@ -893,15 +1363,65 @@ class DatabaseFactory {
         }
 
         @Override
-        PreparedStatement prepareUpsert(Connection c, UUID uuid, long level, String exp, long updatedAt) throws SQLException {
+        PreparedStatement prepareUpsert(
+            Connection c,
+            UUID uuid,
+            long level,
+            String exp,
+            long updatedAt
+        ) throws SQLException {
             String sql =
-                    "INSERT INTO " + qTab(getTable()) + " (" +
-                            qCol("UUID") + "," + qCol("LEVEL") + "," + qCol("EXP") + "," + qCol("UPDATED_AT") + ") " +
-                            "VALUES (?,?,?,?) " +
-                            "ON CONFLICT (" + qCol("UUID") + ") DO UPDATE SET " +
-                            qCol("LEVEL") + " = CASE WHEN EXCLUDED." + qCol("UPDATED_AT") + " >= " + qTab(getTable()) + "." + qCol("UPDATED_AT") + " THEN EXCLUDED." + qCol("LEVEL") + " ELSE " + qTab(getTable()) + "." + qCol("LEVEL") + " END," +
-                            qCol("EXP") + " = CASE WHEN EXCLUDED." + qCol("UPDATED_AT") + " >= " + qTab(getTable()) + "." + qCol("UPDATED_AT") + " THEN EXCLUDED." + qCol("EXP") + " ELSE " + qTab(getTable()) + "." + qCol("EXP") + " END," +
-                            qCol("UPDATED_AT") + " = GREATEST(" + qTab(getTable()) + "." + qCol("UPDATED_AT") + ", EXCLUDED." + qCol("UPDATED_AT") + ")";
+                "INSERT INTO " +
+                qTab(getTable()) +
+                " (" +
+                qCol("UUID") +
+                "," +
+                qCol("LEVEL") +
+                "," +
+                qCol("EXP") +
+                "," +
+                qCol("UPDATED_AT") +
+                ") " +
+                "VALUES (?,?,?,?) " +
+                "ON CONFLICT (" +
+                qCol("UUID") +
+                ") DO UPDATE SET " +
+                qCol("LEVEL") +
+                " = CASE WHEN EXCLUDED." +
+                qCol("UPDATED_AT") +
+                " >= " +
+                qTab(getTable()) +
+                "." +
+                qCol("UPDATED_AT") +
+                " THEN EXCLUDED." +
+                qCol("LEVEL") +
+                " ELSE " +
+                qTab(getTable()) +
+                "." +
+                qCol("LEVEL") +
+                " END," +
+                qCol("EXP") +
+                " = CASE WHEN EXCLUDED." +
+                qCol("UPDATED_AT") +
+                " >= " +
+                qTab(getTable()) +
+                "." +
+                qCol("UPDATED_AT") +
+                " THEN EXCLUDED." +
+                qCol("EXP") +
+                " ELSE " +
+                qTab(getTable()) +
+                "." +
+                qCol("EXP") +
+                " END," +
+                qCol("UPDATED_AT") +
+                " = GREATEST(" +
+                qTab(getTable()) +
+                "." +
+                qCol("UPDATED_AT") +
+                ", EXCLUDED." +
+                qCol("UPDATED_AT") +
+                ")";
             PreparedStatement ps = c.prepareStatement(sql);
             ps.setString(1, uuid.toString());
             ps.setLong(2, level);
@@ -911,14 +1431,42 @@ class DatabaseFactory {
         }
 
         @Override
-        PreparedStatement prepareUpsertMeta(Connection c, UUID uuid, long highest, long updatedAt) throws SQLException {
+        PreparedStatement prepareUpsertMeta(
+            Connection c,
+            UUID uuid,
+            long highest,
+            long updatedAt
+        ) throws SQLException {
             String sql =
-                    "INSERT INTO " + qTab(metaTable()) + " (" +
-                            qCol("UUID") + "," + qCol("HIGHEST_REWARDED") + "," + qCol("UPDATED_AT") + ") " +
-                            "VALUES (?,?,?) " +
-                            "ON CONFLICT (" + qCol("UUID") + ") DO UPDATE SET " +
-                            qCol("HIGHEST_REWARDED") + " = GREATEST(" + qTab(metaTable()) + "." + qCol("HIGHEST_REWARDED") + ", EXCLUDED." + qCol("HIGHEST_REWARDED") + ")," +
-                            qCol("UPDATED_AT") + " = GREATEST(" + qTab(metaTable()) + "." + qCol("UPDATED_AT") + ", EXCLUDED." + qCol("UPDATED_AT") + ")";
+                "INSERT INTO " +
+                qTab(metaTable()) +
+                " (" +
+                qCol("UUID") +
+                "," +
+                qCol("HIGHEST_REWARDED") +
+                "," +
+                qCol("UPDATED_AT") +
+                ") " +
+                "VALUES (?,?,?) " +
+                "ON CONFLICT (" +
+                qCol("UUID") +
+                ") DO UPDATE SET " +
+                qCol("HIGHEST_REWARDED") +
+                " = GREATEST(" +
+                qTab(metaTable()) +
+                "." +
+                qCol("HIGHEST_REWARDED") +
+                ", EXCLUDED." +
+                qCol("HIGHEST_REWARDED") +
+                ")," +
+                qCol("UPDATED_AT") +
+                " = GREATEST(" +
+                qTab(metaTable()) +
+                "." +
+                qCol("UPDATED_AT") +
+                ", EXCLUDED." +
+                qCol("UPDATED_AT") +
+                ")";
             PreparedStatement ps = c.prepareStatement(sql);
             ps.setString(1, uuid.toString());
             ps.setLong(2, highest);
@@ -929,11 +1477,14 @@ class DatabaseFactory {
         @Override
         Set<String> getExistingColumns(Connection conn) throws SQLException {
             Set<String> cols = new HashSet<>();
-            String sql = "SELECT column_name FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = ?";
+            String sql =
+                "SELECT column_name FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = ?";
             try (PreparedStatement ps = conn.prepareStatement(sql)) {
                 ps.setString(1, getTable());
                 try (ResultSet rs = ps.executeQuery()) {
-                    while (rs.next()) cols.add(rs.getString(1).toUpperCase(Locale.ENGLISH));
+                    while (rs.next()) cols.add(
+                        rs.getString(1).toUpperCase(Locale.ENGLISH)
+                    );
                 }
             }
             return cols;
@@ -941,7 +1492,8 @@ class DatabaseFactory {
 
         @Override
         boolean isExpColumnTextual(Connection conn) throws SQLException {
-            String sql = "SELECT data_type FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = ? AND column_name = 'exp'";
+            String sql =
+                "SELECT data_type FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = ? AND column_name = 'exp'";
             try (PreparedStatement ps = conn.prepareStatement(sql)) {
                 ps.setString(1, getTable());
                 try (ResultSet rs = ps.executeQuery()) {
@@ -959,10 +1511,10 @@ class DatabaseFactory {
         @Override
         boolean hasPrimaryKeyOnUuid(Connection conn) throws SQLException {
             String sql =
-                    "SELECT a.attname " +
-                            "FROM pg_index i " +
-                            "JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey) " +
-                            "WHERE i.indrelid = ?::regclass AND i.indisprimary";
+                "SELECT a.attname " +
+                "FROM pg_index i " +
+                "JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey) " +
+                "WHERE i.indrelid = ?::regclass AND i.indisprimary";
             try (PreparedStatement ps = conn.prepareStatement(sql)) {
                 ps.setString(1, getTable());
                 try (ResultSet rs = ps.executeQuery()) {
@@ -977,33 +1529,47 @@ class DatabaseFactory {
 
         @Override
         void createTargetTable(Connection conn) throws SQLException {
-            String sql = "CREATE TABLE IF NOT EXISTS " + qTab(getTable()) + " (" +
-                    qCol("UUID") + " VARCHAR(36) PRIMARY KEY," +
-                    qCol("LEVEL") + " BIGINT," +
-                    qCol("EXP") + " TEXT," +
-                    qCol("UPDATED_AT") + " BIGINT NOT NULL DEFAULT 0" +
-                    ")";
+            String sql =
+                "CREATE TABLE IF NOT EXISTS " +
+                qTab(getTable()) +
+                " (" +
+                qCol("UUID") +
+                " VARCHAR(36) PRIMARY KEY," +
+                qCol("LEVEL") +
+                " BIGINT," +
+                qCol("EXP") +
+                " TEXT," +
+                qCol("UPDATED_AT") +
+                " BIGINT NOT NULL DEFAULT 0" +
+                ")";
             try (Statement st = conn.createStatement()) {
                 st.executeUpdate(sql);
             }
         }
 
         @Override
-        void dropTableIfExists(Connection conn, String table) throws SQLException {
+        void dropTableIfExists(Connection conn, String table)
+            throws SQLException {
             try (Statement st = conn.createStatement()) {
                 st.executeUpdate("DROP TABLE IF EXISTS " + qTab(table));
             }
         }
 
         @Override
-        void renameTable(Connection conn, String from, String to) throws SQLException {
+        void renameTable(Connection conn, String from, String to)
+            throws SQLException {
             try (Statement st = conn.createStatement()) {
-                st.executeUpdate("ALTER TABLE " + qTab(from) + " RENAME TO " + qTab(to));
+                st.executeUpdate(
+                    "ALTER TABLE " + qTab(from) + " RENAME TO " + qTab(to)
+                );
             }
         }
     }
 
-    static <N extends Number> Database<N> createDatabase(CyberLevels main, BaseSystem<N> system) {
+    static <N extends Number> Database<N> createDatabase(
+        CyberLevels main,
+        BaseSystem<N> system
+    ) {
         String type = main.cache().config().database().getType();
 
         switch (type.toUpperCase(Locale.ENGLISH)) {

--- a/src/main/java/com/bitaspire/cyberlevels/UserManagerImpl.java
+++ b/src/main/java/com/bitaspire/cyberlevels/UserManagerImpl.java
@@ -6,16 +6,8 @@ import com.bitaspire.cyberlevels.cache.Lang;
 import com.bitaspire.cyberlevels.user.Database;
 import com.bitaspire.cyberlevels.user.LevelUser;
 import com.bitaspire.cyberlevels.user.UserManager;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import com.bitaspire.scheduler.GlobalRunnable;
 import com.bitaspire.scheduler.GlobalTask;
-import org.apache.commons.lang3.StringUtils;
-import org.bukkit.Bukkit;
-import org.bukkit.OfflinePlayer;
-import org.bukkit.entity.Player;
-import org.jetbrains.annotations.NotNull;
-
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -24,6 +16,13 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
 
 final class UserManagerImpl<N extends Number> implements UserManager<N> {
 
@@ -35,6 +34,7 @@ final class UserManagerImpl<N extends Number> implements UserManager<N> {
     private final Map<UUID, LevelUser<N>> users = new ConcurrentHashMap<>();
 
     GlobalTask autoSaveTask = null;
+
     @Getter
     private Database<N> database = null;
 
@@ -65,9 +65,13 @@ final class UserManagerImpl<N extends Number> implements UserManager<N> {
         final Database<N> now = database;
         if (now != null && old.getClass().equals(now.getClass())) return;
 
-        main.logger("&eDetected database type change from " +
-                old.getClass().getSimpleName() + " to " +
-                (now == null ? "FlatFile" : now.getClass().getSimpleName()) + ". Starting migration...");
+        main.logger(
+            "&eDetected database type change from " +
+                old.getClass().getSimpleName() +
+                " to " +
+                (now == null ? "FlatFile" : now.getClass().getSimpleName()) +
+                ". Starting migration..."
+        );
 
         long start = System.currentTimeMillis();
         int migrated = 0;
@@ -88,9 +92,17 @@ final class UserManagerImpl<N extends Number> implements UserManager<N> {
             }
 
             if (migrated > 0) {
-                main.logger("&aMigrated " + migrated + " users in " + (System.currentTimeMillis() - start) + "ms.");
+                main.logger(
+                    "&aMigrated " +
+                        migrated +
+                        " users in " +
+                        (System.currentTimeMillis() - start) +
+                        "ms."
+                );
             } else {
-                main.logger("&eNo players were found to migrate. Ending migration...");
+                main.logger(
+                    "&eNo players were found to migrate. Ending migration..."
+                );
             }
         } catch (Exception e) {
             main.logger("&cMigration failed.");
@@ -104,8 +116,7 @@ final class UserManagerImpl<N extends Number> implements UserManager<N> {
 
         if (user == null) {
             OfflinePlayer player = Bukkit.getPlayer(uuid);
-            if (player == null)
-                player = Bukkit.getOfflinePlayer(uuid);
+            if (player == null) player = Bukkit.getOfflinePlayer(uuid);
             return loadUser(player);
         }
 
@@ -114,24 +125,46 @@ final class UserManagerImpl<N extends Number> implements UserManager<N> {
 
     @Override
     public LevelUser<N> getUser(String name) {
-        for (LevelUser<N> user : users.values())
-            try {
-                String n = Objects.requireNonNull(user.getName());
-                if (n.equalsIgnoreCase(name)) return user;
-            } catch (Exception ignored) {}
+        if (StringUtils.isBlank(name)) return null;
+
+        Player online = Bukkit.getPlayerExact(name);
+        if (online != null) return getUser(online);
+
+        for (Player player : Bukkit.getOnlinePlayers())
+            if (player.getName().equalsIgnoreCase(name)) return getUser(player);
+
+        for (OfflinePlayer offline : Bukkit.getOfflinePlayers()) {
+            String offlineName = offline.getName();
+            if (
+                offlineName != null && offlineName.equalsIgnoreCase(name)
+            ) return getUser(offline.getUniqueId());
+        }
+
+        for (LevelUser<N> user : users.values()) {
+            String loadedName = user.getName();
+            if (
+                loadedName != null && loadedName.equalsIgnoreCase(name)
+            ) return user;
+        }
 
         return null;
     }
 
     void setRewardLevel(LevelUser<N> user, long level) {
         try {
-            user.getClass().getMethod("setHighestRewardedLevel", long.class).invoke(user, level);
+            user
+                .getClass()
+                .getMethod("setHighestRewardedLevel", long.class)
+                .invoke(user, level);
         } catch (Exception ignored) {}
     }
 
     long getRewardLevel(LevelUser<N> user) {
         try {
-            return (long) user.getClass().getMethod("getHighestRewardedLevel").invoke(user);
+            return (long) user
+                .getClass()
+                .getMethod("getHighestRewardedLevel")
+                .invoke(user);
         } catch (Exception ignored) {
             return user.getLevel();
         }
@@ -140,7 +173,10 @@ final class UserManagerImpl<N extends Number> implements UserManager<N> {
     private LevelUser<N> loadFromFlatFile(UUID uuid) {
         LevelUser<N> user = system.createUser(uuid);
 
-        Path file = new File(main.getDataFolder(), "player_data" + File.separator + uuid + ".clv").toPath();
+        Path file = new File(
+            main.getDataFolder(),
+            "player_data" + File.separator + uuid + ".clv"
+        ).toPath();
         if (!Files.exists(file)) return null;
 
         try (BufferedReader reader = Files.newBufferedReader(file)) {
@@ -155,7 +191,9 @@ final class UserManagerImpl<N extends Number> implements UserManager<N> {
             user.setExp(line.trim(), false, false, false);
 
             line = reader.readLine();
-            long claimed = (line != null) ? Long.parseLong(line.trim()) : user.getLevel();
+            long claimed = (line != null)
+                ? Long.parseLong(line.trim())
+                : user.getLevel();
             setRewardLevel(user, claimed);
 
             return user;
@@ -178,7 +216,9 @@ final class UserManagerImpl<N extends Number> implements UserManager<N> {
             long claimed = getRewardLevel(user);
             writer.write(claimed + "\n");
         } catch (Exception e) {
-            main.logger("&cFailed to save data for UUID " + user.getUuid() + ".");
+            main.logger(
+                "&cFailed to save data for UUID " + user.getUuid() + "."
+            );
             e.printStackTrace();
         }
     }
@@ -192,11 +232,15 @@ final class UserManagerImpl<N extends Number> implements UserManager<N> {
 
             if (user == null) {
                 if ((user = loadFromFlatFile(uuid)) != null) {
-                    migrationMessage = " from flat-file to " + database.getClass().getSimpleName();
+                    migrationMessage =
+                        " from flat-file to " +
+                        database.getClass().getSimpleName();
                     try {
                         database.addUser(user, false);
                     } catch (Exception e) {
-                        main.logger("&cFailed to migrate user to database: " + uuid);
+                        main.logger(
+                            "&cFailed to migrate user to database: " + uuid
+                        );
                     }
                 } else {
                     user = system.createUser(uuid);
@@ -210,7 +254,10 @@ final class UserManagerImpl<N extends Number> implements UserManager<N> {
                 if (old != null) {
                     LevelUser<?> oldUser = old.getUser(uuid);
                     if (oldUser != null) {
-                        migrationMessage = " from " + old.getClass().getSimpleName() + " to flat-file";
+                        migrationMessage =
+                            " from " +
+                            old.getClass().getSimpleName() +
+                            " to flat-file";
                         LevelUser<N> copy = system.createUser(oldUser);
                         saveToFlatFile(copy);
                         user = copy;
@@ -224,7 +271,10 @@ final class UserManagerImpl<N extends Number> implements UserManager<N> {
         return new LoadResult(user, migrationMessage);
     }
 
-    private void loadUserAsync(OfflinePlayer offline, boolean updateLeaderboard) {
+    private void loadUserAsync(
+        OfflinePlayer offline,
+        boolean updateLeaderboard
+    ) {
         Player player = (offline instanceof Player) ? (Player) offline : null;
 
         UUID uuid = offline.getUniqueId();
@@ -236,10 +286,16 @@ final class UserManagerImpl<N extends Number> implements UserManager<N> {
             return;
         }
 
-        main.scheduler().runTaskAsynchronously(() -> {
-            LoadResult result = loadUserData(uuid);
-            main.scheduler().runTask(() -> finishUserLoad(uuid, player, result, updateLeaderboard));
-        });
+        main
+            .scheduler()
+            .runTaskAsynchronously(() -> {
+                LoadResult result = loadUserData(uuid);
+                main
+                    .scheduler()
+                    .runTask(() ->
+                        finishUserLoad(uuid, player, result, updateLeaderboard)
+                    );
+            });
     }
 
     private LevelUser<N> loadUser(OfflinePlayer offline) {
@@ -258,22 +314,34 @@ final class UserManagerImpl<N extends Number> implements UserManager<N> {
         return online;
     }
 
-    private void finishUserLoad(UUID uuid, Player player, LoadResult result, boolean updateLeaderboard) {
-        if (StringUtils.isNotBlank(result.migrationMessage))
-            main.logger("Migrated " + (player != null ? player.getName() : uuid) + result.migrationMessage);
+    private void finishUserLoad(
+        UUID uuid,
+        Player player,
+        LoadResult result,
+        boolean updateLeaderboard
+    ) {
+        if (StringUtils.isNotBlank(result.migrationMessage)) main.logger(
+            "Migrated " +
+                (player != null ? player.getName() : uuid) +
+                result.migrationMessage
+        );
 
         LevelUser<N> existing = users.get(uuid);
         if (existing != null) {
-            if (player != null && !existing.isOnline())
-                users.put(uuid, toOnlineUser(uuid, existing));
+            if (player != null && !existing.isOnline()) users.put(
+                uuid,
+                toOnlineUser(uuid, existing)
+            );
 
             if (updateLeaderboard) scheduleLeaderboardUpdate();
             return;
         }
 
         LevelUser<N> loaded = result.user;
-        if (player != null && !loaded.isOnline())
-            loaded = toOnlineUser(uuid, loaded);
+        if (player != null && !loaded.isOnline()) loaded = toOnlineUser(
+            uuid,
+            loaded
+        );
 
         users.put(uuid, loaded);
         if (updateLeaderboard) scheduleLeaderboardUpdate();
@@ -281,14 +349,17 @@ final class UserManagerImpl<N extends Number> implements UserManager<N> {
 
     private void scheduleLeaderboardUpdate() {
         if (!leaderboardQueued.compareAndSet(false, true)) return;
-        main.scheduler().runTask(() -> {
-            system.updateLeaderboard();
-            leaderboardQueued.set(false);
-        });
+        main
+            .scheduler()
+            .runTask(() -> {
+                system.updateLeaderboard();
+                leaderboardQueued.set(false);
+            });
     }
 
     @RequiredArgsConstructor
     private class LoadResult {
+
         final LevelUser<N> user;
         final String migrationMessage;
     }
@@ -321,10 +392,41 @@ final class UserManagerImpl<N extends Number> implements UserManager<N> {
             setRewardLevel(offline, getRewardLevel(user));
 
             users.put(uuid, offline);
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             users.remove(uuid);
-            main.logger("&cNot able to convert to OfflineUser for: " + user.getName() + ". Deleting cache...");
+            main.logger(
+                "&cNot able to convert to OfflineUser for: " +
+                    user.getName() +
+                    ". Deleting cache..."
+            );
+            e.printStackTrace();
+        }
+    }
+
+    void savePlayerSync(Player player, boolean clearData) {
+        LevelUser<N> user = users.get(player.getUniqueId());
+        if (user == null) return;
+
+        saveUserSync(user);
+        if (!clearData) return;
+
+        UUID uuid = user.getUuid();
+
+        try {
+            LevelUser<N> offline = system.createOffline(uuid);
+            offline.setLevel(user.getLevel(), false);
+            offline.setExp(user.getExp(), false, false, false);
+
+            setRewardLevel(offline, getRewardLevel(user));
+
+            users.put(uuid, offline);
+        } catch (Exception e) {
+            users.remove(uuid);
+            main.logger(
+                "&cNot able to convert to OfflineUser for: " +
+                    user.getName() +
+                    ". Deleting cache..."
+            );
             e.printStackTrace();
         }
     }
@@ -342,6 +444,13 @@ final class UserManagerImpl<N extends Number> implements UserManager<N> {
         main.scheduler().runTaskAsynchronously(() -> saveUser(user));
     }
 
+    void saveUserSync(LevelUser<N> user) {
+        if (database instanceof DatabaseFactory.DatabaseImpl) (
+            (DatabaseFactory.DatabaseImpl<N>) database
+        ).updateUserSync(user);
+        else saveToFlatFile(user);
+    }
+
     @Override
     public void removeUser(UUID uuid) {
         users.remove(uuid);
@@ -351,10 +460,15 @@ final class UserManagerImpl<N extends Number> implements UserManager<N> {
             return;
         }
 
-        File file = new File(main.getDataFolder() + File.separator + "player_data", uuid + ".clv");
+        File file = new File(
+            main.getDataFolder() + File.separator + "player_data",
+            uuid + ".clv"
+        );
         if (!file.exists()) return;
 
-        if (!file.delete()) main.logger("&cFailed to delete flat-file for user " + uuid);
+        if (!file.delete()) main.logger(
+            "&cFailed to delete flat-file for user " + uuid
+        );
     }
 
     void loadOfflinePlayers() {
@@ -384,15 +498,19 @@ final class UserManagerImpl<N extends Number> implements UserManager<N> {
                 if (index < players.length) return;
 
                 cancel();
-                if (loaded > 0)
-                    main.logger("&7Loaded data for &e" + loaded +
-                            " &7offline player(s) in &a" +
-                            (System.currentTimeMillis() - l) +
-                            "ms&7.", "");
+                if (loaded > 0) main.logger(
+                    "&7Loaded data for &e" +
+                        loaded +
+                        " &7offline player(s) in &a" +
+                        (System.currentTimeMillis() - l) +
+                        "ms&7.",
+                    ""
+                );
 
                 scheduleLeaderboardUpdate();
             }
-        }.runTaskTimer(0L, 1L);
+        }
+            .runTaskTimer(0L, 1L);
     }
 
     @Override
@@ -410,10 +528,14 @@ final class UserManagerImpl<N extends Number> implements UserManager<N> {
 
         if (counter < 1) return;
 
-        main.logger("&7Loaded data for &e" + counter +
+        main.logger(
+            "&7Loaded data for &e" +
+                counter +
                 " &7online player(s) in &a" +
                 (System.currentTimeMillis() - l) +
-                "ms&7.", "");
+                "ms&7.",
+            ""
+        );
         scheduleLeaderboardUpdate();
     }
 
@@ -422,26 +544,39 @@ final class UserManagerImpl<N extends Number> implements UserManager<N> {
         Bukkit.getOnlinePlayers().forEach(p -> savePlayer(p, clearData));
     }
 
+    void saveOnlinePlayersSync(boolean clearData) {
+        Bukkit.getOnlinePlayers().forEach(p -> savePlayerSync(p, clearData));
+    }
+
     @Override
     public void startAutoSave() {
         if (!cache.config().isAutoSaveEnabled()) return;
         Config config = cache.config();
 
-        autoSaveTask = main.scheduler().runTaskLater(() -> {
-            long start = System.currentTimeMillis();
-            main.userManager().saveOnlinePlayers(false);
+        autoSaveTask = main
+            .scheduler()
+            .runTaskLater(
+                () -> {
+                    long start = System.currentTimeMillis();
+                    main.userManager().saveOnlinePlayers(false);
 
-            if (config.syncLeaderboardOnAutoSave())
-                system.getLeaderboard().update();
+                    if (config.syncLeaderboardOnAutoSave()) system
+                        .getLeaderboard()
+                        .update();
 
-            if (config.isMessagesOnAutoSave())
-                cache.lang().sendMessage(
-                        null, Lang::getAutoSave, "ms",
-                        System.currentTimeMillis() - start
-                );
+                    if (config.isMessagesOnAutoSave()) cache
+                        .lang()
+                        .sendMessage(
+                            null,
+                            Lang::getAutoSave,
+                            "ms",
+                            System.currentTimeMillis() - start
+                        );
 
-            startAutoSave();
-        }, 20L * config.getAutoSaveInterval());
+                    startAutoSave();
+                },
+                20L * config.getAutoSaveInterval()
+            );
     }
 
     @Override

--- a/src/main/java/com/bitaspire/cyberlevels/UserManagerImpl.java
+++ b/src/main/java/com/bitaspire/cyberlevels/UserManagerImpl.java
@@ -231,13 +231,7 @@ final class UserManagerImpl<N extends Number> implements UserManager<N> {
         LevelUser<N> user = users.get(uuid);
 
         if (user != null && player != null && !user.isOnline()) {
-            LevelUser<N> newUser = system.createUser(uuid);
-
-            newUser.setLevel(user.getLevel(), false);
-            newUser.setExp(user.getExp() + "", true, false, false);
-            setRewardLevel(newUser, getRewardLevel(user));
-
-            users.put(uuid, newUser);
+            users.put(uuid, toOnlineUser(uuid, user));
             if (updateLeaderboard) scheduleLeaderboardUpdate();
             return;
         }
@@ -249,17 +243,39 @@ final class UserManagerImpl<N extends Number> implements UserManager<N> {
     }
 
     private LevelUser<N> loadUser(OfflinePlayer offline) {
+        UUID uuid = offline.getUniqueId();
         Player player = (offline instanceof Player) ? (Player) offline : null;
-        LoadResult result = loadUserData(offline.getUniqueId());
-        finishUserLoad(offline.getUniqueId(), player, result, true);
-        return result.user;
+        LoadResult result = loadUserData(uuid);
+        finishUserLoad(uuid, player, result, true);
+        return users.getOrDefault(uuid, result.user);
+    }
+
+    private LevelUser<N> toOnlineUser(UUID uuid, LevelUser<N> source) {
+        LevelUser<N> online = system.createUser(uuid);
+        online.setLevel(source.getLevel(), false);
+        online.setExp(source.getExp() + "", true, false, false);
+        setRewardLevel(online, getRewardLevel(source));
+        return online;
     }
 
     private void finishUserLoad(UUID uuid, Player player, LoadResult result, boolean updateLeaderboard) {
         if (StringUtils.isNotBlank(result.migrationMessage))
             main.logger("Migrated " + (player != null ? player.getName() : uuid) + result.migrationMessage);
 
-        users.put(uuid, result.user);
+        LevelUser<N> existing = users.get(uuid);
+        if (existing != null) {
+            if (player != null && !existing.isOnline())
+                users.put(uuid, toOnlineUser(uuid, existing));
+
+            if (updateLeaderboard) scheduleLeaderboardUpdate();
+            return;
+        }
+
+        LevelUser<N> loaded = result.user;
+        if (player != null && !loaded.isOnline())
+            loaded = toOnlineUser(uuid, loaded);
+
+        users.put(uuid, loaded);
         if (updateLeaderboard) scheduleLeaderboardUpdate();
     }
 

--- a/src/main/java/com/bitaspire/cyberlevels/command/CLVCommand.java
+++ b/src/main/java/com/bitaspire/cyberlevels/command/CLVCommand.java
@@ -4,16 +4,15 @@ import com.bitaspire.cyberlevels.CyberLevels;
 import com.bitaspire.cyberlevels.cache.Lang;
 import com.bitaspire.cyberlevels.level.LevelSystem;
 import com.bitaspire.cyberlevels.user.LevelUser;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
 import lombok.Getter;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.function.Function;
 
 public class CLVCommand implements CommandExecutor {
 
@@ -22,15 +21,33 @@ public class CLVCommand implements CommandExecutor {
 
     public CLVCommand(CyberLevels main) {
         this.main = main;
-        this.consoleCmds = Arrays.asList("about", "reload", "addexp", "setexp", "removeexp", "addlevel", "setlevel", "removelevel", "purge");
+        this.consoleCmds = Arrays.asList(
+            "about",
+            "reload",
+            "addexp",
+            "setexp",
+            "removeexp",
+            "addlevel",
+            "setlevel",
+            "removelevel",
+            "purge"
+        );
     }
 
     @Override
-    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command cmd, @NotNull String label, String[] args) {
+    public boolean onCommand(
+        @NotNull CommandSender sender,
+        @NotNull Command cmd,
+        @NotNull String label,
+        String[] args
+    ) {
         Player player = (sender instanceof Player) ? (Player) sender : null;
 
         // Console restrictions
-        if (player == null && (args.length == 0 || !consoleCmds.contains(args[0].toLowerCase()))) {
+        if (
+            player == null &&
+            (args.length == 0 || !consoleCmds.contains(args[0].toLowerCase()))
+        ) {
             main.logger("&cConsole cannot use this command!");
             return true;
         }
@@ -41,12 +58,20 @@ public class CLVCommand implements CommandExecutor {
         if (args.length == 1) {
             switch (sub) {
                 case "about":
-                    return isRestricted(player, "player.about") || main.createSender(player).send(
-                            " &d&lCyber&f&lLevels &fv" + main.getDescription().getVersion() + " &7(&7&nhttps://bit.ly/2YSlqYq&7).",
-                            " &fDeveloped by &d" + main.getAuthors() + "&f.",
-                            " A leveling system plugin with MySQL support and custom events."
+                    return (
+                        isRestricted(player, "player.about") ||
+                        main
+                            .createSender(player)
+                            .send(
+                                " &d&lCyber&f&lLevels &fv" +
+                                    main.getDescription().getVersion() +
+                                    " &7(&7&nhttps://bit.ly/2YSlqYq&7).",
+                                " &fDeveloped by &d" +
+                                    main.getAuthors() +
+                                    "&f.",
+                                " A leveling system plugin with MySQL support and custom events."
+                            )
                     );
-
                 case "reload":
                     if (isRestricted(player, "admin.reload")) return true;
 
@@ -54,23 +79,39 @@ public class CLVCommand implements CommandExecutor {
                     main.onDisable();
                     main.reloadPlugin();
 
-                    return main.cache().lang().sendMessage(player, Lang::getReloaded);
-
-                case "info": return sendLevelInfo(player);
-
+                    return main
+                        .cache()
+                        .lang()
+                        .sendMessage(player, Lang::getReloaded);
+                case "info":
+                    return sendLevelInfo(player);
                 case "top":
                     if (isRestricted(player, "player.top")) return true;
 
                     main.cache().lang().sendMessage(player, Lang::getTopHeader);
                     int i = 1;
 
-                    for (LevelUser<?> user : main.levelSystem().getLeaderboard().getTopTenPlayers()) {
-                        main.cache().lang().sendMessage(
-                                player, Lang::getTopContent,
-                                new String[] {"position", "player", "level", "exp"},
-                                i++, user.getName(),
-                                user.getLevel(), user.getExp()
-                        );
+                    for (LevelUser<?> user : main
+                        .levelSystem()
+                        .getLeaderboard()
+                        .getTopTenPlayers()) {
+                        main
+                            .cache()
+                            .lang()
+                            .sendMessage(
+                                player,
+                                Lang::getTopContent,
+                                new String[] {
+                                    "position",
+                                    "player",
+                                    "level",
+                                    "exp",
+                                },
+                                i++,
+                                user.getName(),
+                                user.getLevel(),
+                                user.getExp()
+                            );
                     }
 
                     main.cache().lang().sendMessage(player, Lang::getTopFooter);
@@ -83,7 +124,15 @@ public class CLVCommand implements CommandExecutor {
             if (target != null) {
                 main.userManager().removeUser(target.getUuid());
                 main.levelSystem().getLeaderboard().update();
-                return main.cache().lang().sendMessage(player, Lang::getPurgePlayer, "player", args[1]);
+                return main
+                    .cache()
+                    .lang()
+                    .sendMessage(
+                        player,
+                        Lang::getPurgePlayer,
+                        "player",
+                        args[1]
+                    );
             }
 
             return isRestricted(player, "admin.info") || sendLevelInfo(player);
@@ -93,23 +142,49 @@ public class CLVCommand implements CommandExecutor {
             if (isRestricted(player, "admin.info")) return true;
 
             LevelUser<?> target = main.userManager().getUser(args[1]);
-            if (target == null)
-                return main.cache().lang().sendMessage(player, Lang::getPlayerNotFound, "player", args[1]);
+            if (target == null) return main
+                .cache()
+                .lang()
+                .sendMessage(
+                    player,
+                    Lang::getPlayerNotFound,
+                    "player",
+                    args[1]
+                );
 
             return sendLevelInfo(player, target);
         }
 
         if (args.length >= 2) {
-            LevelUser<?> user = null;
-
-            if (args.length == 3)
-                user = main.userManager().getUser(args[2]);
-
-            if (user == null && player != null)
-                user = main.userManager().getUser(player);
+            String targetName = args.length >= 3 ? args[2] : null;
+            LevelUser<?> user =
+                targetName != null
+                    ? main.userManager().getUser(targetName)
+                    : (player != null
+                          ? main.userManager().getUser(player)
+                          : null);
 
             if (user == null) {
-                main.cache().lang().sendMessage(player, Lang::getPlayerNotFound, "player", args[2]);
+                if (targetName == null) {
+                    if (player == null) {
+                        main.logger(
+                            "&cConsole must specify a player name for this command."
+                        );
+                        return true;
+                    }
+
+                    return sendLevelInfo(player);
+                }
+
+                main
+                    .cache()
+                    .lang()
+                    .sendMessage(
+                        player,
+                        Lang::getPlayerNotFound,
+                        "player",
+                        targetName
+                    );
                 return true;
             }
 
@@ -117,31 +192,69 @@ public class CLVCommand implements CommandExecutor {
 
             switch (sub) {
                 case "addexp":
-                    return handleExp(player, user, value, "exp.add", true, ExpAction.ADD);
-
+                    return handleExp(
+                        player,
+                        user,
+                        value,
+                        "exp.add",
+                        true,
+                        ExpAction.ADD
+                    );
                 case "setexp":
-                    return handleExp(player, user, value, "exp.set", true, ExpAction.SET);
-
+                    return handleExp(
+                        player,
+                        user,
+                        value,
+                        "exp.set",
+                        true,
+                        ExpAction.SET
+                    );
                 case "removeexp":
-                    return handleExp(player, user, value, "exp.remove", false, ExpAction.REMOVE);
-
+                    return handleExp(
+                        player,
+                        user,
+                        value,
+                        "exp.remove",
+                        false,
+                        ExpAction.REMOVE
+                    );
                 case "addlevel":
-                    return handleLevel(player, user, value, "level.add", LevelAction.ADD);
-
+                    return handleLevel(
+                        player,
+                        user,
+                        value,
+                        "level.add",
+                        LevelAction.ADD
+                    );
                 case "setlevel":
-                    return handleLevel(player, user, value, "level.set", LevelAction.SET);
-
+                    return handleLevel(
+                        player,
+                        user,
+                        value,
+                        "level.set",
+                        LevelAction.SET
+                    );
                 case "removelevel":
-                    return handleLevel(player, user, value, "level.remove", LevelAction.REMOVE);
+                    return handleLevel(
+                        player,
+                        user,
+                        value,
+                        "level.remove",
+                        LevelAction.REMOVE
+                    );
             }
         }
 
         if (player != null) {
-            if (player.hasPermission("CyberLevels.admin.help"))
-                return main.cache().lang().sendMessage(player, Lang::getHelpAdmin);
+            if (player.hasPermission("CyberLevels.admin.help")) return main
+                .cache()
+                .lang()
+                .sendMessage(player, Lang::getHelpAdmin);
 
-            if (player.hasPermission("CyberLevels.player.help"))
-                return main.cache().lang().sendMessage(player, Lang::getHelpPlayer);
+            if (player.hasPermission("CyberLevels.player.help")) return main
+                .cache()
+                .lang()
+                .sendMessage(player, Lang::getHelpPlayer);
         }
 
         return main.cache().lang().sendMessage(player, Lang::getNoPermission);
@@ -151,24 +264,49 @@ public class CLVCommand implements CommandExecutor {
         LevelUser<?> user = main.userManager().getUser(player);
         LevelSystem<?> system = main.levelSystem();
 
-        return main.cache().lang().sendMessage(
-                player, Lang::getLevelInfo,
-                new String[] {"player", "level", "maxLevel", "playerEXP", "requiredEXP", "percent", "progressBar"},
-                user.getName(), user.getLevel(),
+        return main
+            .cache()
+            .lang()
+            .sendMessage(
+                player,
+                Lang::getLevelInfo,
+                new String[] {
+                    "player",
+                    "level",
+                    "maxLevel",
+                    "playerEXP",
+                    "requiredEXP",
+                    "percent",
+                    "progressBar",
+                },
+                user.getName(),
+                user.getLevel(),
                 main.cache().levels().getMaxLevel(),
                 system.formatNumber(user.getExp()),
                 system.formatNumber(user.getRequiredExp()),
                 user.getPercent(),
                 user.getProgressBar()
-        );
+            );
     }
 
     private boolean sendLevelInfo(Player viewer, LevelUser<?> target) {
         LevelSystem<?> system = main.levelSystem();
 
-        return main.cache().lang().sendMessage(
-                viewer, Lang::getLevelInfo,
-                new String[]{"player","level","maxLevel","playerEXP","requiredEXP","percent","progressBar"},
+        return main
+            .cache()
+            .lang()
+            .sendMessage(
+                viewer,
+                Lang::getLevelInfo,
+                new String[] {
+                    "player",
+                    "level",
+                    "maxLevel",
+                    "playerEXP",
+                    "requiredEXP",
+                    "percent",
+                    "progressBar",
+                },
                 target.getName(),
                 target.getLevel(),
                 main.cache().levels().getMaxLevel(),
@@ -176,10 +314,17 @@ public class CLVCommand implements CommandExecutor {
                 system.formatNumber(target.getRequiredExp()),
                 target.getPercent(),
                 target.getProgressBar()
-        );
+            );
     }
 
-    private boolean handleExp(Player player, LevelUser<?> user, String arg, String perm, boolean allowMultiplier, ExpAction action) {
+    private boolean handleExp(
+        Player player,
+        LevelUser<?> user,
+        String arg,
+        String perm,
+        boolean allowMultiplier,
+        ExpAction action
+    ) {
         perm = "admin.levels." + perm;
 
         if (isRestricted(player, perm) || notDouble(player, arg)) return true;
@@ -187,7 +332,10 @@ public class CLVCommand implements CommandExecutor {
 
         switch (action) {
             case ADD:
-                user.addExp(value + "", main.cache().config().isMultiplierCommands());
+                user.addExp(
+                    value + "",
+                    main.cache().config().isMultiplierCommands()
+                );
                 break;
             case SET:
                 user.setExp(value + "", allowMultiplier, true, true);
@@ -199,14 +347,32 @@ public class CLVCommand implements CommandExecutor {
 
         LevelSystem<?> system = main.levelSystem();
 
-        return main.cache().lang().sendMessage(
-                player, action.getMessage(),
-                new String[] {"player", action.getPlaceholder(), "level", "playerEXP"},
-                user.getName(), arg, user.getLevel(), system.formatNumber(user.getExp())
-        );
+        return main
+            .cache()
+            .lang()
+            .sendMessage(
+                player,
+                action.getMessage(),
+                new String[] {
+                    "player",
+                    action.getPlaceholder(),
+                    "level",
+                    "playerEXP",
+                },
+                user.getName(),
+                arg,
+                user.getLevel(),
+                system.formatNumber(user.getExp())
+            );
     }
 
-    private boolean handleLevel(Player player, LevelUser<?> user, String arg, String perm, LevelAction action) {
+    private boolean handleLevel(
+        Player player,
+        LevelUser<?> user,
+        String arg,
+        String perm,
+        LevelAction action
+    ) {
         if (isRestricted(player, perm) || notLong(player, arg)) return true;
         long value = Math.abs(Long.parseLong(arg));
 
@@ -224,16 +390,31 @@ public class CLVCommand implements CommandExecutor {
 
         LevelSystem<?> system = main.levelSystem();
 
-        return main.cache().lang().sendMessage(
-                player, action.getMessage(),
-                new String[] {"player", action.getPlaceholder(), "level", "playerEXP"},
-                user.getName(), arg, user.getLevel(), system.formatNumber(user.getExp())
-        );
+        return main
+            .cache()
+            .lang()
+            .sendMessage(
+                player,
+                action.getMessage(),
+                new String[] {
+                    "player",
+                    action.getPlaceholder(),
+                    "level",
+                    "playerEXP",
+                },
+                user.getName(),
+                arg,
+                user.getLevel(),
+                system.formatNumber(user.getExp())
+            );
     }
 
     private boolean isRestricted(Player player, String permissionKey) {
-        return player != null && (!player.hasPermission("CyberLevels." + permissionKey) &&
-                main.cache().lang().sendMessage(player, Lang::getNoPermission));
+        return (
+            player != null &&
+            (!player.hasPermission("CyberLevels." + permissionKey) &&
+                main.cache().lang().sendMessage(player, Lang::getNoPermission))
+        );
     }
 
     private boolean notLong(Player player, String arg) {
@@ -260,6 +441,7 @@ public class CLVCommand implements CommandExecutor {
         REMOVE(Lang::getRemovedExp, "removedEXP");
 
         private final Function<Lang, List<String>> lang;
+
         @Getter
         private final String placeholder;
 
@@ -279,6 +461,7 @@ public class CLVCommand implements CommandExecutor {
         REMOVE(Lang::getRemovedLevels, "removedLevels");
 
         private final Function<Lang, List<String>> lang;
+
         @Getter
         private final String placeholder;
 

--- a/src/main/java/com/bitaspire/cyberlevels/hook/PlaceholderAPI.java
+++ b/src/main/java/com/bitaspire/cyberlevels/hook/PlaceholderAPI.java
@@ -54,7 +54,8 @@ final class PlaceholderAPI implements Hook {
                 LevelUser<?> user = system.getLeaderboard().getTopPlayer(position);
 
                 Lang.LeaderboardKeys keys = main.cache().lang().leaderboardKeys();
-                String value = user == null ? keys.getLoadingName() : keys.getNoPlayerName();
+                String value = system.getLeaderboard().isUpdating() ?
+                        keys.getLoadingName() : keys.getNoPlayerName();
 
                 if (user != null) {
                     switch (type.toLowerCase()) {
@@ -85,6 +86,7 @@ final class PlaceholderAPI implements Hook {
                 switch (identifier.toLowerCase()) {
                     case "level_maximum": return system.getMaxLevel() + "";
                     case "exp_minimum": return system.getStartExp() + "";
+                    case "experience_minimum": return system.getStartExp() + "";
                     case "level_minimum":  return system.getStartLevel() + "";
                 }
 
@@ -105,21 +107,27 @@ final class PlaceholderAPI implements Hook {
                         return String.valueOf(user.getLevel());
 
                     case "player_level_next":
+                    case "player_next_level":
                         return (Math.min(user.getLevel() + 1, system.getMaxLevel())) + "";
 
                     case "player_exp":
+                    case "player_experience":
                         return system.formatNumber(user.getExp());
 
                     case "player_exp_required":
+                    case "player_experience_required":
                         return system.formatNumber(user.getRequiredExp());
 
                     case "player_exp_remaining":
+                    case "player_experience_remaining":
                         return system.formatNumber(user.getRemainingExp());
 
                     case "player_exp_progress_bar":
+                    case "player_experience_progress_bar":
                         return main.library().colorize(user.getProgressBar());
 
                     case "player_exp_percent":
+                    case "player_experience_percent":
                         return user.getPercent();
                 }
 

--- a/src/main/java/com/bitaspire/cyberlevels/listener/Listeners.java
+++ b/src/main/java/com/bitaspire/cyberlevels/listener/Listeners.java
@@ -49,7 +49,6 @@ public class Listeners {
             }
         };
 
-        register();
     }
 
     public void register() {


### PR DESCRIPTION
This pull request introduces improvements to user loading logic, enhances PlaceholderAPI support for experience-related placeholders, and refines leaderboard status handling. The changes aim to make user state transitions more robust, provide more flexible placeholder options, and improve clarity in leaderboard display.

**User loading and state management:**
* Refactored the user loading process in `UserManagerImpl.java` to ensure that offline users are properly converted to online users using the new `toOnlineUser` method, reducing code duplication and improving clarity. [[1]](diffhunk://#diff-45487b22efbec478bd99518fb1222cc95419f1da3b402e27b26870364276d873L234-R234) [[2]](diffhunk://#diff-45487b22efbec478bd99518fb1222cc95419f1da3b402e27b26870364276d873R246-R278)

**PlaceholderAPI enhancements:**
* Added support for additional experience-related placeholders (e.g., `experience_minimum`, `player_experience`, `player_experience_required`, etc.) in `PlaceholderAPI.java`, making the API more flexible and consistent for plugin users. [[1]](diffhunk://#diff-9e8ebda961a04130de33e9e9809bc94eceb2570aa01d304da7055cdac5c873b1R89) [[2]](diffhunk://#diff-9e8ebda961a04130de33e9e9809bc94eceb2570aa01d304da7055cdac5c873b1R110-R130)

**Leaderboard display improvements:**
* Updated leaderboard placeholder logic to show a loading name when the leaderboard is updating, rather than always showing a no-player name, improving user feedback during leaderboard updates.

**Listener registration cleanup:**
* Removed a redundant call to `register()` within the piston retract event handler in `Listeners.java`, preventing unnecessary registration logic.…; enhance PlaceholderAPI with additional experience-related identifiers; remove unused register call in Listeners.