### PR TITLE
Fix leaderboard access to prevent index errors using snapshots

### DIFF
--- a/src/main/java/com/bitaspire/cyberlevels/BaseSystem.java
+++ b/src/main/java/com/bitaspire/cyberlevels/BaseSystem.java
@@ -325,9 +325,10 @@ abstract class BaseSystem<N extends Number> implements LevelSystem<N> {
             if (updating || position < 1 || position > 10) return null;
 
             int index = position - 1;
-            if (index >= topTenPlayers.size()) return null;
+            List<Entry<T>> snapshot = new ArrayList<>(topTenPlayers);
+            if (index >= snapshot.size()) return null;
 
-            return userManager.getUser(topTenPlayers.get(index).getUuid());
+            return userManager.getUser(snapshot.get(index).getUuid());
         }
 
         int check(UUID uuid) {


### PR DESCRIPTION
This pull request makes a minor adjustment to the `getTopPlayer` method in `BaseSystem.java` to improve the safety and consistency of retrieving top player data.

* Data consistency improvement: The method now creates a snapshot of the `topTenPlayers` list before accessing it, ensuring that the list does not change during the operation and preventing potential concurrency issues.