### PR TITLE
fix: improve leaderboard and database sync

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "com.bitaspire"
-version = "1.1.3"
+version = "1.1.4"
 
 repositories {
     mavenLocal()

--- a/src/main/java/com/bitaspire/cyberlevels/BaseSystem.java
+++ b/src/main/java/com/bitaspire/cyberlevels/BaseSystem.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.NotNull;
 import java.math.RoundingMode;
 import java.text.DecimalFormat;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Function;
@@ -307,7 +308,8 @@ abstract class BaseSystem<N extends Number> implements LevelSystem<N> {
 
         private final UserManager<T> userManager;
 
-        private volatile boolean updating = false;
+        private final AtomicBoolean updating = new AtomicBoolean(false);
+        private final AtomicBoolean dirty = new AtomicBoolean(false);
         protected final List<Entry<T>> topTenPlayers = new CopyOnWriteArrayList<>();
 
         BaseLeaderboard(UserManager<T> manager) {
@@ -321,8 +323,14 @@ abstract class BaseSystem<N extends Number> implements LevelSystem<N> {
 
         @Override
         public void update() {
+            dirty.set(true);
+            if (updating.compareAndSet(false, true))
+                runUpdatePass();
+        }
+
+        private void runUpdatePass() {
+            dirty.set(false);
             List<LevelUser<T>> users = userManager.getUsersList();
-            updating = true;
 
             main.scheduler().runTaskAsynchronously(() -> {
                 List<Entry<T>> list = new ArrayList<>();
@@ -330,20 +338,35 @@ abstract class BaseSystem<N extends Number> implements LevelSystem<N> {
 
                 list.sort(Comparator.naturalOrder());
                 int max = cache.config().getLeaderboardMaxPositions();
-                List<Entry<T>> top = list.subList(0, Math.min(max, list.size()));
+                List<Entry<T>> top = new ArrayList<>(list.subList(0, Math.min(max, list.size())));
 
-                main.scheduler().runTask(() -> {
-                    topTenPlayers.clear();
-                    topTenPlayers.addAll(top);
-                    updating = false;
-                });
+                main.scheduler().runTask(() -> finishUpdatePass(top));
             });
+        }
+
+        private void finishUpdatePass(List<Entry<T>> top) {
+            topTenPlayers.clear();
+            topTenPlayers.addAll(top);
+
+            if (dirty.get()) {
+                runUpdatePass();
+                return;
+            }
+
+            updating.set(false);
+            if (dirty.get() && updating.compareAndSet(false, true))
+                runUpdatePass();
+        }
+
+        @Override
+        public boolean isUpdating() {
+            return updating.get();
         }
 
         @Override
         public LevelUser<T> getTopPlayer(int position) {
             int max = cache.config().getLeaderboardMaxPositions();
-            if (updating || position < 1 || position > max) return null;
+            if (updating.get() || position < 1 || position > max) return null;
 
             int index = position - 1;
             List<Entry<T>> snapshot = new ArrayList<>(topTenPlayers);

--- a/src/main/java/com/bitaspire/cyberlevels/UserManagerImpl.java
+++ b/src/main/java/com/bitaspire/cyberlevels/UserManagerImpl.java
@@ -28,12 +28,14 @@ import java.util.concurrent.atomic.AtomicBoolean;
 final class UserManagerImpl<N extends Number> implements UserManager<N> {
 
     private static final long DATABASE_SYNC_INTERVAL_TICKS = 20L;
+    private static final long DATABASE_SYNC_LOOKBACK_MS = 1_500L;
     private static final long LOCAL_OFFLINE_CACHE_TTL_MS = 15_000L;
 
     final CyberLevels main;
     final Cache cache;
 
     private final AtomicBoolean leaderboardQueued = new AtomicBoolean(false);
+    private final AtomicBoolean leaderboardDirty = new AtomicBoolean(false);
     private final AtomicBoolean databaseSyncInFlight = new AtomicBoolean(false);
     private final BaseSystem<N> system;
     private final Map<UUID, LevelUser<N>> users = new ConcurrentHashMap<>();
@@ -336,8 +338,11 @@ final class UserManagerImpl<N extends Number> implements UserManager<N> {
             if (player != null && !existing.isOnline())
                 users.put(uuid, toOnlineUser(uuid, existing));
 
-            if (result.databaseUpdatedAt > 0L)
+            if (result.databaseUpdatedAt > 0L) {
                 knownDatabaseUpdatedAt.put(uuid, result.databaseUpdatedAt);
+                lastObservedDatabaseUpdateAt = Math.max(lastObservedDatabaseUpdateAt, result.databaseUpdatedAt);
+            }
+
             if (player != null) localOfflineSnapshots.remove(uuid);
             if (updateLeaderboard) scheduleLeaderboardUpdate();
             return;
@@ -347,18 +352,30 @@ final class UserManagerImpl<N extends Number> implements UserManager<N> {
         if (player != null && !loaded.isOnline()) loaded = toOnlineUser(uuid, loaded);
 
         users.put(uuid, loaded);
-        if (result.databaseUpdatedAt > 0L)
+        if (result.databaseUpdatedAt > 0L) {
             knownDatabaseUpdatedAt.put(uuid, result.databaseUpdatedAt);
+            lastObservedDatabaseUpdateAt = Math.max(lastObservedDatabaseUpdateAt, result.databaseUpdatedAt);
+        }
+
         if (player != null) localOfflineSnapshots.remove(uuid);
         if (updateLeaderboard) scheduleLeaderboardUpdate();
     }
 
     private void scheduleLeaderboardUpdate() {
+        leaderboardDirty.set(true);
         if (!leaderboardQueued.compareAndSet(false, true)) return;
-        main.scheduler().runTask(() -> {
+        main.scheduler().runTask(this::drainLeaderboardUpdates);
+    }
+
+    private void drainLeaderboardUpdates() {
+        do {
+            leaderboardDirty.set(false);
             system.updateLeaderboard();
-            leaderboardQueued.set(false);
-        });
+        } while (leaderboardDirty.get());
+
+        leaderboardQueued.set(false);
+        if (leaderboardDirty.get() && leaderboardQueued.compareAndSet(false, true))
+            main.scheduler().runTask(this::drainLeaderboardUpdates);
     }
 
     @RequiredArgsConstructor
@@ -513,8 +530,7 @@ final class UserManagerImpl<N extends Number> implements UserManager<N> {
 
         main.logger("&7Loaded data for &e" + counter +
                 " &7online player(s) in &a" +
-                (System.currentTimeMillis() - l) +
-                "ms&7.", "");
+                (System.currentTimeMillis() - l) + "ms&7.", "");
         scheduleLeaderboardUpdate();
     }
 
@@ -527,11 +543,8 @@ final class UserManagerImpl<N extends Number> implements UserManager<N> {
         Bukkit.getOnlinePlayers().forEach(p -> savePlayer(p, true, true));
     }
 
-    @SuppressWarnings("unchecked")
     private DatabaseFactory.DatabaseImpl<N> databaseImpl() {
-        return database instanceof DatabaseFactory.DatabaseImpl<?> ?
-                (DatabaseFactory.DatabaseImpl<N>) database :
-                null;
+        return (DatabaseFactory.DatabaseImpl<N>) database;
     }
 
     void startDatabaseSync() {
@@ -556,8 +569,9 @@ final class UserManagerImpl<N extends Number> implements UserManager<N> {
         if (!databaseSyncInFlight.compareAndSet(false, true)) return;
 
         try {
+            long queryAfter = Math.max(0L, lastObservedDatabaseUpdateAt - DATABASE_SYNC_LOOKBACK_MS);
             List<DatabaseFactory.DatabaseImpl.StoredUserData> updates =
-                    databaseImpl.getUsersUpdatedSince(lastObservedDatabaseUpdateAt);
+                    databaseImpl.getUsersUpdatedSince(queryAfter);
 
             if (updates.isEmpty()) return;
 


### PR DESCRIPTION
## Summary
- bump version to 1.1.4
- coalesce leaderboard updates with database sync processing
- reduce missed or duplicated leaderboard refreshes during rapid user updates

## Commits
- chore: bump version to 1.1.4
- fix: coalesce leaderboard and database sync