### PR TITLE
feat: add specific exp stacking controls

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "com.bitaspire"
-version = "1.1.5"
+version = "1.1.6"
 
 repositories {
     mavenLocal()

--- a/src/main/java/com/bitaspire/cyberlevels/cache/EarnExp.java
+++ b/src/main/java/com/bitaspire/cyberlevels/cache/EarnExp.java
@@ -395,7 +395,10 @@ public class EarnExp {
         return new Listener() {
             @EventHandler(priority = EventPriority.HIGHEST)
             public void onDamage(EntityDamageByEntityEvent event) {
-                if (!source.isEnabled() || !filter.test(event.getEntity()) || event.isCancelled()) return;
+                if ((!source.isEnabled() && !source.useSpecifics()) ||
+                        !filter.test(event.getEntity()) ||
+                        event.isCancelled())
+                    return;
 
                 Entity attacker = event.getDamager();
                 if ((attacker instanceof Projectile) && (((Projectile) attacker).getShooter() instanceof Player))
@@ -418,7 +421,9 @@ public class EarnExp {
         return new Listener() {
             @EventHandler(priority = EventPriority.HIGHEST)
             public void onDeath(EntityDeathEvent event) {
-                if (!source.isEnabled() || !filter.test(event.getEntity())) return;
+                if ((!source.isEnabled() && !source.useSpecifics()) ||
+                        !filter.test(event.getEntity()))
+                    return;
 
                 EntityDamageEvent cause = event.getEntity().getLastDamageCause();
                 if (!(cause instanceof EntityDamageByEntityEvent)) return;
@@ -443,14 +448,15 @@ public class EarnExp {
     void sendExp(Player player, ExpSource source, String value) {
         if (main.levelSystem().checkAntiAbuse(player, source)) return;
         double counter = 0;
+        String matched = source.useSpecifics() ? source.matchSpecificKey(value) : null;
 
-        if (source.useSpecifics()) {
-            String matched = source.matchSpecificKey(value);
-            if (matched != null) counter = source.getSpecificRange(matched).getRandom();
-        }
-        else if (source.isEnabled()) {
-            if (source.isInList(value)) counter = source.getRange().getRandom();
-        }
+        if (source.isEnabled() &&
+                source.isInList(value) &&
+                (matched == null || source.stackSpecificsWithGeneral()))
+            counter += source.getRange().getRandom();
+
+        if (matched != null)
+            counter += source.getSpecificRange(matched).getRandom();
 
         if (counter == 0) return;
 
@@ -468,17 +474,18 @@ public class EarnExp {
             return;
 
         double counter = 0;
+        boolean hasSpecific = source.useSpecifics() && source.hasPermission(player, true);
 
-        if (source.useSpecifics()) {
-            if (source.hasPermission(player, true))
-                for (String s : source.getSpecificList()) {
-                    if (!player.hasPermission(s)) continue;
-                    counter += source.getSpecificRange(s).getRandom();
-                }
-        }
-        else if (source.isEnabled()) {
-            if (source.hasPermission(player)) counter = source.getRange().getRandom();
-        }
+        if (source.isEnabled() &&
+                source.hasPermission(player) &&
+                (!hasSpecific || source.stackSpecificsWithGeneral()))
+            counter += source.getRange().getRandom();
+
+        if (hasSpecific)
+            for (String s : source.getSpecificList()) {
+                if (!player.hasPermission(s)) continue;
+                counter += source.getSpecificRange(s).getRandom();
+            }
 
         if (counter == 0) return;
 
@@ -555,6 +562,7 @@ public class EarnExp {
         private final List<String> list;
 
         private final boolean specific;
+        private final boolean stackSpecificsWithGeneral;
         @Getter(AccessLevel.NONE)
         private final Map<String, Range> specifics = new HashMap<>();
 
@@ -575,6 +583,7 @@ public class EarnExp {
             list = getList("general.includes.list");
 
             specific = get("specific-" + specificName + ".enabled", false);
+            stackSpecificsWithGeneral = get("specific-" + specificName + ".stack-with-general", true);
             if (specific) {
                 for (String key : getList("specific-" + specificName + "." + specificName)) {
                     String[] array = key.split(":", 2);
@@ -627,6 +636,11 @@ public class EarnExp {
         @Override
         public boolean useSpecifics() {
             return specific;
+        }
+
+        @Override
+        public boolean stackSpecificsWithGeneral() {
+            return stackSpecificsWithGeneral;
         }
 
         @NotNull
@@ -705,29 +719,32 @@ public class EarnExp {
 
         public double getPartialMatchesExp(String string) {
             String upper = string.toUpperCase(Locale.ENGLISH);
-            if (!enabled) return 0.0;
+            double amount = 0.0;
+            boolean matchedSpecific = false;
 
             if (specific && !specifics.isEmpty()) {
-                double amount = 0.0;
-
-                for (String s : specifics.keySet())
-                    if (upper.contains(s.toUpperCase(Locale.ENGLISH)))
+                for (String s : specifics.keySet()) {
+                    if (upper.contains(s.toUpperCase(Locale.ENGLISH))) {
                         amount += getSpecificRange(s).getRandom();
-
-                return amount;
+                        matchedSpecific = true;
+                    }
+                }
             }
 
-            if (includes) return getRange().getRandom();
+            if (!enabled || (matchedSpecific && !stackSpecificsWithGeneral))
+                return amount;
+
+            if (!includes)
+                return amount + getRange().getRandom();
 
             boolean giveExp = true;
-            double amount = 0.0;
 
             for (String s : list) {
                 if (!upper.contains(s.toUpperCase(Locale.ENGLISH)))
                     continue;
 
                 if (whitelist)
-                    return getRange().getRandom();
+                    return amount + getRange().getRandom();
 
                 giveExp = false;
                 break;
@@ -751,6 +768,7 @@ public class EarnExp {
                     ", whitelist=" + whitelist +
                     ", list=" + list +
                     ", specific=" + specific +
+                    ", stackSpecificsWithGeneral=" + stackSpecificsWithGeneral +
                     ", specifics=" + specifics +
                     '}';
         }

--- a/src/main/java/com/bitaspire/cyberlevels/hook/HookManager.java
+++ b/src/main/java/com/bitaspire/cyberlevels/hook/HookManager.java
@@ -63,16 +63,15 @@ public class HookManager {
         if (main.levelSystem().checkAntiAbuse(player, source)) return;
 
         double counter = 0;
+        String matched = source.useSpecifics() ? source.matchSpecificKey(item) : null;
 
-        if (source.useSpecifics()) {
-            String matched = source.matchSpecificKey(item);
-            if (matched != null)
-                counter = source.getSpecificRange(matched).getRandom();
-        }
-        else if (source.isEnabled()) {
-            if (source.isInList(item))
-                counter = source.getRange().getRandom();
-        }
+        if (source.isEnabled() &&
+                source.isInList(item) &&
+                (matched == null || source.stackSpecificsWithGeneral()))
+            counter += source.getRange().getRandom();
+
+        if (matched != null)
+            counter += source.getSpecificRange(matched).getRandom();
 
         if (counter == 0) return;
 

--- a/src/main/java/com/bitaspire/cyberlevels/level/ExpSource.java
+++ b/src/main/java/com/bitaspire/cyberlevels/level/ExpSource.java
@@ -83,6 +83,16 @@ public interface ExpSource {
     boolean useSpecifics();
 
     /**
+     * Indicates whether matching specific values should be added to the general reward.
+     *
+     * <p>When disabled, a matching specific value replaces the general reward for that runtime
+     * value. Values that do not match a specific entry may still receive the general reward.
+     *
+     * @return {@code true} when specific rewards stack with the general reward
+     */
+    boolean stackSpecificsWithGeneral();
+
+    /**
      * Returns the configured specific keys for this source.
      *
      * @return specific map keys available for matching

--- a/src/main/resources/addons/levelled-mobs.yml
+++ b/src/main/resources/addons/levelled-mobs.yml
@@ -20,6 +20,7 @@ earn-exp:
     specific-animals:
       # These WILL stack on the ones above.
       enabled: false
+      stack-with-general: true
       animals:
         - '3:COW-1,6: 1, 2'
         - 'SHEEP: 1, 2'
@@ -41,6 +42,7 @@ earn-exp:
     specific-monsters:
       # These WILL stack on the ones above.
       enabled: false
+      stack-with-general: true
       min-level: 2
       monsters:
         - 'SPIDER: 1, 2'

--- a/src/main/resources/earn-exp.yml
+++ b/src/main/resources/earn-exp.yml
@@ -16,6 +16,7 @@ earn-exp:
     specific-permissions:
       # These WILL stack on the ones above.
       enabled: false
+      stack-with-general: true
       permissions:
         - 'permission.vip: 2, 4'
         - 'permission.mvp: 3, 5'
@@ -35,6 +36,7 @@ earn-exp:
       # These WILL stack on the ones above. Could be
       # used to reduce EXP loss for special users.
       enabled: false
+      stack-with-general: true
       permissions:
         - 'permission.vip: 1, 2'
         - 'permission.mvp: 2, 3'
@@ -54,6 +56,7 @@ earn-exp:
     specific-players:
       # These WILL stack on the ones above.
       enabled: false
+      stack-with-general: true
       players:
         - 'CroaBeast: 2, 4'
         - 'ThiccPickle: 3, 5'
@@ -73,6 +76,7 @@ earn-exp:
     specific-animals:
       # These WILL stack on the ones above.
       enabled: false
+      stack-with-general: true
       animals:
         - 'COW: 1, 2'
         - 'SHEEP: 1, 2'
@@ -93,6 +97,7 @@ earn-exp:
     specific-monsters:
       # These WILL stack on the ones above.
       enabled: false
+      stack-with-general: true
       monsters:
         - 'SPIDER: 1, 2'
         - 'CREEPER: 1, 2'
@@ -112,6 +117,7 @@ earn-exp:
     specific-players:
       # These WILL stack on the ones above.
       enabled: false
+      stack-with-general: true
       players:
         - 'CroaBeast: 2, 4'
         - 'ThiccPickle: 3, 5'
@@ -131,6 +137,7 @@ earn-exp:
     specific-animals:
       # These WILL stack on the ones above.
       enabled: false
+      stack-with-general: true
       animals:
         - 'COW: 1, 2'
         - 'SHEEP: 1, 2'
@@ -151,6 +158,7 @@ earn-exp:
     specific-monsters:
       # These WILL stack on the ones above.
       enabled: false
+      stack-with-general: true
       monsters:
         - 'SPIDER: 1, 2'
         - 'CREEPER: 1, 2'
@@ -170,6 +178,7 @@ earn-exp:
           - "NETHERRACK"
     specific-blocks:
       enabled: false
+      stack-with-general: true
       blocks:
         - 'DIAMOND_ORE: 4, 6'
 
@@ -188,6 +197,7 @@ earn-exp:
           - "NETHERRACK"
     specific-blocks:
       enabled: false
+      stack-with-general: true
       blocks:
         - 'DIAMOND_ORE: 4, 6'
 
@@ -205,6 +215,7 @@ earn-exp:
           - "MUTTON"
     specific-items:
       enabled: false
+      stack-with-general: true
       items:
         - 'GOLDEN_APPLE: 4, 6'
 
@@ -219,6 +230,7 @@ earn-exp:
           - 'permission.no.exp'
     specific-permissions:
       enabled: false
+      stack-with-general: true
       permissions:
         - 'permission.vip: 1, 2'
         - 'permission.mvp: 2, 3'
@@ -236,6 +248,7 @@ earn-exp:
           - "WOODEN_PICKAXE"
     specific-items:
       enabled: false
+      stack-with-general: true
       items:
         - 'DIAMOND_BLOCK: 10, 15'
 
@@ -251,6 +264,7 @@ earn-exp:
           - "HUNGER"
     specific-potions:
       enabled: false
+      stack-with-general: true
       potions:
         - 'SPEED: 1, 3'
         - 'HEAL: 1, 2'
@@ -268,6 +282,7 @@ earn-exp:
           - "UNBREAKING-2"
     specific-enchantments:
       enabled: false
+      stack-with-general: true
       enchantments:
         - 'KNOCKBACK-1: 1, 3'
         - 'LURE: 1, 2'
@@ -286,6 +301,7 @@ earn-exp:
           - "STRING"
     specific-fish:
       enabled: false
+      stack-with-general: true
       fish:
         - 'COD: 2, 3'
         - 'SALMON: 2, 3'
@@ -302,6 +318,7 @@ earn-exp:
           - "CHICKEN"
     specific-animals:
       enabled: false
+      stack-with-general: true
       animals:
         - 'SHEEP: 2, 3'
         - 'DOG: 2, 3'
@@ -321,6 +338,7 @@ earn-exp:
           - "oh hi mark"
     specific-words:
       enabled: false
+      stack-with-general: true
       words:
         - 'HELLO: 1, 2'
         - 'AWESOME: 1, 2'
@@ -342,6 +360,7 @@ earn-exp:
           - 2
     specific-amounts:
       enabled: false
+      stack-with-general: true
       # If a player earns 5 via vanilla system, they
       # will earn between 2 and 3 EXP in CLV for the
       # first example below.
@@ -363,6 +382,7 @@ earn-exp:
           - "BEET_ROOT"
     specific-blocks:
       enabled: false
+      stack-with-general: true
       blocks:
         - 'CARROT: 4, 6'
 
@@ -379,5 +399,6 @@ earn-exp:
           - "GRASS_BLOCK"
     specific-blocks:
       enabled: false
+      stack-with-general: true
       blocks:
         - 'DIAMOND_ORE: 4, 6'


### PR DESCRIPTION
## Summary
- bump version to 1.1.6
- add `stack-with-general` support for specific EXP sources
- allow specific EXP rewards to run without requiring the general source reward
- update default earn-exp and LevelledMobs examples to document the new behavior

## Commits
- chore: bump version to 1.1.6
- feat: add specific exp stacking controls