### PR TITLE
feat: enable CLV level rewards by default

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "com.bitaspire"
-version = "1.2.3"
+version = "1.2.4"
 
 repositories {
     mavenLocal()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "com.bitaspire"
-version = "1.2.4"
+version = "1.2.5"
 
 repositories {
     mavenLocal()

--- a/src/main/java/com/bitaspire/cyberlevels/command/CLVTabComplete.java
+++ b/src/main/java/com/bitaspire/cyberlevels/command/CLVTabComplete.java
@@ -36,6 +36,9 @@ public class CLVTabComplete implements TabCompleter {
     private static final Set<String> MUTATION_COMMANDS = Collections.unmodifiableSet(new HashSet<>(
         Arrays.asList("addexp", "setexp", "removeexp", "addlevel", "setlevel", "removelevel")
     ));
+    private static final List<String> CONSOLE_COMMANDS = Collections.unmodifiableList(
+        Arrays.asList("about", "reload", "addexp", "setexp", "removeexp", "addlevel", "setlevel", "removelevel", "purge")
+    );
     private static final Map<String, String> COMMAND_PERMISSIONS = new LinkedHashMap<>();
 
     static {
@@ -73,26 +76,29 @@ public class CLVTabComplete implements TabCompleter {
      */
     @Override
     public List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String alias, String[] args) {
-        if (!(sender instanceof Player)) return Collections.emptyList();
-        Player player = (Player) sender;
+        Player player = sender instanceof Player ? (Player) sender : null;
 
         if (args.length == 1) {
             List<String> available = new ArrayList<>();
-            COMMAND_PERMISSIONS.forEach((cmd, perm) -> {
-                if (player.hasPermission(perm)) available.add(cmd);
-            });
+            if (player == null) {
+                available.addAll(CONSOLE_COMMANDS);
+            } else {
+                COMMAND_PERMISSIONS.forEach((cmd, perm) -> {
+                    if (player.hasPermission(perm)) available.add(cmd);
+                });
+            }
             return partialMatch(args[0], available);
         }
 
         if (args.length == 2) {
             switch (args[0].toLowerCase()) {
                 case "info":
-                    if (player.hasPermission(ADMIN_PREFIX + "list"))
+                    if (player != null && player.hasPermission(ADMIN_PREFIX + "list"))
                         return partialMatch(args[1], getPlayerNames());
                     break;
 
                 case "purge":
-                    if (player.hasPermission(ADMIN_PREFIX + "purge"))
+                    if (player == null || player.hasPermission(ADMIN_PREFIX + "purge"))
                         return partialMatch(args[1], getPlayerNames());
                     break;
 

--- a/src/main/java/com/bitaspire/cyberlevels/command/CLVTabComplete.java
+++ b/src/main/java/com/bitaspire/cyberlevels/command/CLVTabComplete.java
@@ -51,13 +51,13 @@ public class CLVTabComplete implements TabCompleter {
         COMMAND_PERMISSIONS.put("list", ADMIN_PREFIX + "list");
         COMMAND_PERMISSIONS.put("purge", ADMIN_PREFIX + "purge");
 
-        COMMAND_PERMISSIONS.put("addExp", ADMIN_PREFIX + "exp.add");
-        COMMAND_PERMISSIONS.put("setExp", ADMIN_PREFIX + "exp.set");
-        COMMAND_PERMISSIONS.put("removeExp", ADMIN_PREFIX + "exp.remove");
+        COMMAND_PERMISSIONS.put("addexp", ADMIN_PREFIX + "exp.add");
+        COMMAND_PERMISSIONS.put("setexp", ADMIN_PREFIX + "exp.set");
+        COMMAND_PERMISSIONS.put("removeexp", ADMIN_PREFIX + "exp.remove");
 
-        COMMAND_PERMISSIONS.put("addLevel", ADMIN_PREFIX + "levels.add");
-        COMMAND_PERMISSIONS.put("setLevel", ADMIN_PREFIX + "levels.set");
-        COMMAND_PERMISSIONS.put("removeLevel", ADMIN_PREFIX + "levels.remove");
+        COMMAND_PERMISSIONS.put("addlevel", ADMIN_PREFIX + "levels.add");
+        COMMAND_PERMISSIONS.put("setlevel", ADMIN_PREFIX + "levels.set");
+        COMMAND_PERMISSIONS.put("removelevel", ADMIN_PREFIX + "levels.remove");
     }
 
     private final CyberLevels main;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -63,7 +63,7 @@ config:
     load-offline-users: true
 
   # Should adding levels give rewards?
-  add-level-reward: false
+  add-level-reward: true
 
   # Should getting rewards multiple times per
   # level be prevented?


### PR DESCRIPTION
## Summary
- bump version to 1.2.5
- match CLV tab command permissions
- enable level rewards by default

## Commits
- chore: bump version to 1.2.5
- fix: match CLV tab command permissions
- feat: enable CLV level rewards by default

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BitAspire/codesmith/CyberLevels/pr/30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781901447&installation_id=128932147&pr_number=30&repository=BitAspire%2FCyberLevels&return_to=https%3A%2F%2Fgithub.com%2FBitAspire%2FCyberLevels%2Fpull%2F30&signature=60dc0d84501cbbb2d4863c59a23a2dcf314926c104e1dc8f330fb71f8f202239"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->