### PR TITLE
fix: dispatch reward commands on main thread for Folia compat (#31)

### DIFF
--- a/src/main/java/com/bitaspire/cyberlevels/cache/Rewards.java
+++ b/src/main/java/com/bitaspire/cyberlevels/cache/Rewards.java
@@ -102,19 +102,21 @@ public final class Rewards {
         }
 
         public void executeCommands(Player player) {
-            for (String command : commands) {
-                command = command.trim();
+            for (String rawCommand : commands) {
+                String command = rawCommand.trim();
                 if (StringUtils.isBlank(command)) continue;
 
                 if (main.isEnabled("PlaceholderAPI"))
                     command = PlaceholderAPI.setPlaceholders(player, main.levelSystem().replacePlaceholders(command, player.getUniqueId(), false));
 
-                if (command.toLowerCase().startsWith("[player]")) {
-                    Bukkit.dispatchCommand(player, parseFormat("[player]", command));
-                    continue;
-                }
-
-                Bukkit.dispatchCommand(Bukkit.getConsoleSender(), parseFormat("[console]", command));
+                final String toExecute = command;
+                Bukkit.getScheduler().runTask(main, () -> {
+                    if (toExecute.toLowerCase().startsWith("[player]")) {
+                        Bukkit.dispatchCommand(player, parseFormat("[player]", toExecute));
+                    } else {
+                        Bukkit.dispatchCommand(Bukkit.getConsoleSender(), parseFormat("[console]", toExecute));
+                    }
+                });
             }
         }
 


### PR DESCRIPTION
Fixes #31

## Problem
On Folia-based servers,  throws  because it must run on the global tick thread. Level-up reward commands fire from event handlers on region threads.

## Fix
Wrap  calls in  so they execute synchronously on the main thread.

## Verification
-  now dispatched via scheduler task
- Player/console commands both handled correctly
- Spigot/Paper servers unaffected (scheduler works everywhere)

/claim #31

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BitAspire/codesmith/CyberLevels/pr/32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781969604&installation_id=128932147&pr_number=32&repository=BitAspire%2FCyberLevels&return_to=https%3A%2F%2Fgithub.com%2FBitAspire%2FCyberLevels%2Fpull%2F32&signature=8287a8a405c239052abed54cfae81f3247976dfa3169b35fc076acc8705f4ac3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->